### PR TITLE
Allow passing additional headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ resp = client.put_object("bucket_name", "object_key", "myobjectbody")
 resp.etag # => ...
 ```
 
+You can also pass additional headers (e.g. metadata):
+
+```crystal
+client.put_object("bucket_name", "object_key", "myobjectbody", {"x-amz-meta-name" => "myobject"})
+```
+
 ## **Get Object**
 
 ```crystal
@@ -64,6 +70,14 @@ uploader = Awscr::S3::FileUploader.new(client)
 
 File.open(File.expand_path("myfile"), "r") do |file|
   puts uploader.upload("bucket_name", "someobjectkey", file)
+end
+```
+
+You can also pass additional headers (e.g. metadata):
+
+```crystal
+File.open(File.expand_path("myfile"), "r") do |file|
+  puts uploader.upload("bucket_name", "someobjectkey", file, {"x-amz-meta-name" => "myobject"})
 end
 ```
 

--- a/spec/awscr-s3/file_uploader_spec.cr
+++ b/spec/awscr-s3/file_uploader_spec.cr
@@ -1,0 +1,89 @@
+require "../../spec_helper"
+
+module Awscr::S3
+  describe FileUploader do
+    describe "when the file is smaller than 5MB" do
+      it "uploads it in one call" do
+        WebMock.stub(:put, "http://s3.amazonaws.com/bucket/object?")
+               .with(body: "document")
+               .to_return(status: 200, body: "", headers: {"ETag" => "etag"})
+
+        client = Client.new("us-east-1", "key", "secret")
+        uploader = FileUploader.new(client)
+        small_io = IO::Memory.new("document")
+
+        uploader.upload("bucket", "object", small_io)
+      end
+
+      it "passes additional headers, when provided" do
+        WebMock.stub(:put, "http://s3.amazonaws.com/bucket/object?")
+               .with(body: "document", headers: {"x-amz-meta-name" => "myobject"})
+               .to_return(status: 200, body: "", headers: {"ETag" => "etag"})
+
+        client = Client.new("us-east-1", "key", "secret")
+        uploader = FileUploader.new(client)
+        small_io = IO::Memory.new("document")
+
+        uploader.upload("bucket", "object", small_io, {"x-amz-meta-name" => "myobject"})
+      end
+    end
+
+    describe "when the file is larger than 5MB" do
+      it "uploads it in chunks" do
+        # Start multipart upload
+        WebMock.stub(:post, "http://s3.amazonaws.com/bucket/object")
+               .with(query: {"uploads" => ""})
+               .to_return(status: 200, body: Fixtures.start_multipart_upload_response(upload_id: "123"))
+
+        # Upload part 1
+        WebMock.stub(:put, "http://s3.amazonaws.com/bucket/object")
+               .with(query: {"partNumber" => "1", "uploadId" => "123"})
+               .to_return(status: 200, body: "", headers: {"ETag" => "etag"})
+
+        # Upload part 2
+        WebMock.stub(:put, "http://s3.amazonaws.com/bucket/object")
+               .with(query: {"partNumber" => "2", "uploadId" => "123"})
+               .to_return(status: 200, body: "", headers: {"ETag" => "etag"})
+
+        # Complete multipart upload
+        WebMock.stub(:post, "http://s3.amazonaws.com/bucket/object?uploadId=123")
+               .with(body: "<?xml version=\"1.0\"?>\n<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>etag</ETag></Part><Part><PartNumber>2</PartNumber><ETag>etag</ETag></Part></CompleteMultipartUpload>\n")
+               .to_return(status: 200, body: Fixtures.complete_multipart_upload_response)
+
+        client = Client.new("us-east-1", "key", "secret")
+        uploader = FileUploader.new(client)
+        big_io = IO::Memory.new("a" * 5_500_000)
+
+        uploader.upload("bucket", "object", big_io)
+      end
+
+      it "passes additional headers, when provided" do
+        # Start multipart upload
+        WebMock.stub(:post, "http://s3.amazonaws.com/bucket/object")
+               .with(query: {"uploads" => ""}, headers: {"x-amz-meta-name" => "myobject"})
+               .to_return(status: 200, body: Fixtures.start_multipart_upload_response(upload_id: "123"))
+
+        # Upload part 1
+        WebMock.stub(:put, "http://s3.amazonaws.com/bucket/object")
+               .with(query: {"partNumber" => "1", "uploadId" => "123"})
+               .to_return(status: 200, body: "", headers: {"ETag" => "etag"})
+
+        # Upload part 2
+        WebMock.stub(:put, "http://s3.amazonaws.com/bucket/object")
+               .with(query: {"partNumber" => "2", "uploadId" => "123"})
+               .to_return(status: 200, body: "", headers: {"ETag" => "etag"})
+
+        # Complete multipart upload
+        WebMock.stub(:post, "http://s3.amazonaws.com/bucket/object?uploadId=123")
+               .with(body: "<?xml version=\"1.0\"?>\n<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>etag</ETag></Part><Part><PartNumber>2</PartNumber><ETag>etag</ETag></Part></CompleteMultipartUpload>\n")
+               .to_return(status: 200, body: Fixtures.complete_multipart_upload_response)
+
+        client = Client.new("us-east-1", "key", "secret")
+        uploader = FileUploader.new(client)
+        big_io = IO::Memory.new("a" * 5_500_000)
+
+        uploader.upload("bucket", "object", big_io, {"x-amz-meta-name" => "myobject"})
+      end
+    end
+  end
+end

--- a/spec/fixtures.cr
+++ b/spec/fixtures.cr
@@ -1,0 +1,24 @@
+module Fixtures
+  def self.start_multipart_upload_response(bucket = "bucket", key = "object", upload_id = "FxtGq8otGhDtYJa5VYLpPOBQo2niM2a1YR8wgcwqHJ1F1Djflj339mEfpm7NbYOoIg.6bIPeXl2RB82LuAnUkTQUEz_ReIu2wOwawGc0Z4SLERxoXospqANXDazuDmRF")
+    <<-RESP
+      <?xml version="1.0" encoding="UTF-8"?>
+      <InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Bucket>#{bucket}</Bucket>
+        <Key>#{key}</Key>
+        <UploadId>#{upload_id}</UploadId>
+      </InitiateMultipartUploadResult>
+    RESP
+  end
+
+  def self.complete_multipart_upload_response
+    <<-RESP_BODY
+      <?xml version="1.0" encoding="UTF-8"?>
+        <CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Location>http://s3.amazonaws.com/screensnapr-development/test</Location>
+        <Bucket>screensnapr-development</Bucket>
+        <Key>test</Key>
+        <ETag>\"7611c6414e4b58f22ff9f59a2c1767b7-2\"</ETag>
+      </CompleteMultipartUploadResult>
+    RESP_BODY
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,11 +1,16 @@
 require "spec"
 require "timecop"
 require "webmock"
+require "./fixtures"
 
 struct Time
   def self.utc_now
     Timecop.now
   end
+end
+
+Spec.before_each do
+  WebMock.reset
 end
 
 require "../src/awscr-s3"

--- a/src/awscr-s3/client.cr
+++ b/src/awscr-s3/client.cr
@@ -14,8 +14,9 @@ module Awscr::S3
       Response::ListAllMyBuckets.from_response(resp)
     end
 
-    def start_multipart_upload(bucket : String, object : String)
-      resp = http.post("/#{bucket}/#{object}?uploads")
+    def start_multipart_upload(bucket : String, object : String,
+                               headers : Hash(String, String) = Hash(String, String).new)
+      resp = http.post("/#{bucket}/#{object}?uploads", headers: headers)
 
       Response::StartMultipartUpload.from_response(resp)
     end
@@ -64,14 +65,15 @@ module Awscr::S3
       true
     end
 
-    def delete_object(bucket, object)
-      resp = http.delete("/#{bucket}/#{object}")
+    def delete_object(bucket, object, headers : Hash(String, String) = Hash(String, String).new)
+      resp = http.delete("/#{bucket}/#{object}", headers)
 
       resp.status_code == 204
     end
 
-    def put_object(bucket, object : String, body : IO | String)
-      resp = http.put("/#{bucket}/#{object}", body)
+    def put_object(bucket, object : String, body : IO | String,
+                   headers : Hash(String, String) = Hash(String, String).new)
+      resp = http.put("/#{bucket}/#{object}", body, headers)
 
       Response::PutObjectOutput.from_response(resp)
     end

--- a/src/awscr-s3/file_uploader.cr
+++ b/src/awscr-s3/file_uploader.cr
@@ -7,12 +7,12 @@ module Awscr::S3
     def initialize(@client : Client)
     end
 
-    def upload(bucket : String, object : String, io : IO)
+    def upload(bucket : String, object : String, io : IO, headers : Hash(String, String) = Hash(String, String).new)
       if io.size < UPLOAD_THRESHOLD
-        client.put_object(bucket, object, io)
+        client.put_object(bucket, object, io, headers)
       else
         uploader = MultipartFileUploader.new(client)
-        uploader.upload(bucket, object, io)
+        uploader.upload(bucket, object, io, headers)
       end
     end
   end

--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -24,18 +24,21 @@ module Awscr::S3
       end
     end
 
-    def delete(path)
-      resp = @http.delete(path)
+    def delete(path, headers : Hash(String, String) = Hash(String, String).new)
+      headers = HTTP::Headers.new.merge!(headers)
+      resp = @http.delete(path, headers: headers)
       handle_response!(resp)
     end
 
-    def post(path, body = nil)
-      resp = @http.post(path, body: body)
+    def post(path, body = nil, headers : Hash(String, String) = Hash(String, String).new)
+      headers = HTTP::Headers.new.merge!(headers)
+      resp = @http.post(path, headers: headers, body: body)
       handle_response!(resp)
     end
 
-    def put(path : String, body : IO | String)
-      resp = @http.put(path, headers: HTTP::Headers{"Content-Length" => body.size.to_s}, body: body)
+    def put(path : String, body : IO | String, headers : Hash(String, String) = Hash(String, String).new)
+      headers = HTTP::Headers{"Content-Length" => body.size.to_s}.merge!(headers)
+      resp = @http.put(path, headers: headers, body: body)
       handle_response!(resp)
     end
 

--- a/src/awscr-s3/multipart_file_uploader.cr
+++ b/src/awscr-s3/multipart_file_uploader.cr
@@ -14,6 +14,7 @@ module Awscr::S3
     @upload_id : String?
     @bucket : String?
     @object : String?
+    @headers : Hash(String, String)?
 
     def initialize(@client : Client)
       @pending = [] of Part
@@ -21,9 +22,10 @@ module Awscr::S3
       @channel = Channel(Nil).new
     end
 
-    def upload(bucket : String, object : String, io : IO)
+    def upload(bucket : String, object : String, io : IO, headers : Hash(String, String) = Hash(String, String).new)
       @bucket = bucket
       @object = object
+      @headers = headers
       @upload_id = start_upload
 
       build_pending_parts(io)
@@ -100,7 +102,7 @@ module Awscr::S3
     end
 
     private def start_upload
-      resp = client.start_multipart_upload(bucket, object)
+      resp = client.start_multipart_upload(bucket, object, headers)
       resp.upload_id
     end
 
@@ -114,6 +116,10 @@ module Awscr::S3
 
     private def object
       @object.not_nil!
+    end
+
+    private def headers
+      @headers.not_nil!
     end
   end
 end


### PR DESCRIPTION
hello

first of all thanks for this, wasn't hoping to find an S3 client written in Crystal :1st_place_medal: 

as explained [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html), S3 allows passing metadata through headers. same goes for DigitalOcean Spaces, which is the service I'm more interested in and for which I've also raised https://github.com/taylorfinnell/awscr-s3/issues/14

anyway, it works for both and would be great to see it part of your project :)