### PR TITLE
Updates for new version of signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ For S3 compatible services, like DigitalOcean Spaces or Minio, you'll need to se
 client = Awscr::S3::Client.new("nyc3", "key", "secret", endpoint: "https://nyc3.digitaloceanspaces.com")
 ```
 
+If you wish you wish to you version 2 request signing you may specify the signer
+
+```crystal
+client = Awscr::S3::Client.new("us-east1", "key", "secret", signer: :v2)
+```
+
 ## **List Buckets**
 
 ```crystal
@@ -103,6 +109,14 @@ form = Awscr::S3::Presigned::Form.build("us-east-1", "access key", "secret key")
 end
 ```
 
+You may use version 2 request signing via
+
+```crystal
+form = Awscr::S3::Presigned::Form.build("us-east-1", "access key", "secret key", signer: :v2) do |form|
+  ...
+end
+```
+
 **Converting the form to raw HTML (for browser uploads, etc).**
 
 ```crystal
@@ -131,4 +145,18 @@ options = Awscr::S3::Presigned::Url::Options.new(
 
 url = Awscr::S3::Presigned::Url.new(options)
 p url.for(:put)
+```
+
+You may use version 2 request signing via
+
+
+```crystal
+options = Awscr::S3::Presigned::Url::Options.new(
+   aws_access_key: "key",
+   aws_secret_key: "secret",
+   region: "us-east-1",
+   object: "test.txt",
+   bucket: "mybucket",
+   signer: :v2
+)
 ```

--- a/examples/version_2_signing.cr
+++ b/examples/version_2_signing.cr
@@ -1,0 +1,24 @@
+require "../src/awscr-s3"
+require "secure_random"
+
+BUCKET = ENV["AWS_BUCKET"]
+KEY    = ENV["AWS_KEY"]
+SECRET = ENV["AWS_SECRET"]
+REGION = ENV["AWS_REGION"]
+
+object = "/#{SecureRandom.uuid}"
+
+options = Awscr::S3::Presigned::Url::Options.new(
+  region: REGION,
+  object: object,
+  bucket: BUCKET,
+  aws_access_key: KEY,
+  aws_secret_key: SECRET,
+  signer: :v2
+)
+
+url = Awscr::S3::Presigned::Url.new(options)
+
+HTTP::Client.put(url.for(:put), HTTP::Headers.new, body: "Howdy!")
+resp = HTTP::Client.get(url.for(:get))
+p "Object #{object}: #{resp.body}"

--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   awscr-signer:
     github: taylorfinnell/awscr-signer
-    version: ~> 0.3.6
+    version: ~> 0.4.0
 
 development_dependencies:
   timecop:

--- a/spec/awscr-s3/bucket_spec.cr
+++ b/spec/awscr-s3/bucket_spec.cr
@@ -1,0 +1,15 @@
+require "../spec_helper"
+
+module Awscr::S3
+  describe Bucket do
+    it "is equal to another bucket if name and creation time are equal" do
+      bucket = Bucket.new("test", "123")
+      Bucket.new("test", "123").should eq(bucket)
+    end
+
+    it "not equal to another bucket if name and creation time differ" do
+      bucket = Bucket.new("test2", "123")
+      (Bucket.new("test", "123") == bucket).should eq(false)
+    end
+  end
+end

--- a/spec/awscr-s3/client_spec.cr
+++ b/spec/awscr-s3/client_spec.cr
@@ -2,6 +2,10 @@ require "../spec_helper"
 
 module Awscr::S3
   describe Client do
+    it "allows signer version" do
+      Client.new("adasd", "adasd", "adad", signer: :v2)
+    end
+
     describe "abort_multipart_upload" do
       it "aborts an upload" do
         WebMock.stub(:delete, "http://s3.amazonaws.com/bucket/object?uploadId=upload_id")

--- a/spec/awscr-s3/object_spec.cr
+++ b/spec/awscr-s3/object_spec.cr
@@ -1,0 +1,30 @@
+require "../spec_helper"
+
+module Awscr::S3
+  describe Object do
+    it "is equal to another object if key size and etag are same" do
+      object = Object.new("test", 123, "etag")
+      Object.new("test", 123, "etag").should eq(object)
+    end
+
+    it "not equal to another object key size and etag" do
+      object = Object.new("test2", 123, "etag")
+      (Object.new("test", 123, "asd") == object).should eq(false)
+    end
+
+    it "has key" do
+      object = Object.new("test", 123, "etag")
+      object.key.should eq("test")
+    end
+
+    it "has size" do
+      object = Object.new("test", 123, "etag")
+      object.size.should eq(123)
+    end
+
+    it "has etag" do
+      object = Object.new("test", 123, "etag")
+      object.etag.should eq("etag")
+    end
+  end
+end

--- a/spec/awscr-s3/presigned/form_spec.cr
+++ b/spec/awscr-s3/presigned/form_spec.cr
@@ -18,6 +18,19 @@ module Awscr
           end
         end
 
+        describe "url" do
+          it "returns form url" do
+            form = Form.build(
+              region: "us-east-1",
+              aws_access_key: "test",
+              aws_secret_key: "test") do |f|
+              f.condition("bucket", "hi")
+            end
+
+            form.url.should eq("http://hi.s3.amazonaws.com")
+          end
+        end
+
         describe "fields" do
           it "is a field collection" do
             post = Post.new(
@@ -45,13 +58,16 @@ module Awscr
         end
 
         describe "submit" do
-          it "sends a reasonable request over http" do
+          it "sends a reasonable request over http for v2" do
+            time = Time.epoch(1)
+            Timecop.freeze(time)
+
             post = Post.new(
               region: "us-east-1",
               aws_access_key: "test",
-              aws_secret_key: "test"
+              aws_secret_key: "test",
+              signer: :v2
             )
-            time = Time.epoch(1)
 
             post.build do |builder|
               builder.expiration(time)
@@ -65,6 +81,39 @@ module Awscr
 
               HTTP::Client::Response.new(200, body: "")
             end
+
+            post.fields["Signature"].should eq("2OuTzB6hWfTJsU6UuN4mLuVEHpY=")
+
+            client = HTTP::Client.new("fake host")
+            io = IO::Memory.new("test")
+            form = Form.new(post, client)
+            resp = form.submit(io)
+          end
+
+          it "sends a reasonable request over http for v4" do
+            time = Time.epoch(1)
+            Timecop.freeze(time)
+
+            post = Post.new(
+              region: "us-east-1",
+              aws_access_key: "test",
+              aws_secret_key: "test"
+            )
+
+            post.build do |builder|
+              builder.expiration(time)
+              builder.condition("bucket", "test")
+              builder.condition("key", "hi")
+            end
+
+            WebMock.stub(:post, "http://fake host/").to_return do |request|
+              request.headers.not_nil!["Content-Type"].nil?.should eq false
+              request.body.nil?.should eq false
+
+              HTTP::Client::Response.new(200, body: "")
+            end
+
+            post.fields["X-Amz-Signature"].should eq("db2a7f49b8c2b1513db3f85416ea04d38cb4a55b39f6c4a56b0bd83b41594a3d")
 
             client = HTTP::Client.new("fake host")
             io = IO::Memory.new("test")

--- a/spec/awscr-s3/presigned/post_spec.cr
+++ b/spec/awscr-s3/presigned/post_spec.cr
@@ -181,7 +181,31 @@ module Awscr
         end
 
         describe "build" do
-          it "yields the policy" do
+          it "yields signed v2 policy" do
+            post = Post.new(
+              region: "us-east-1",
+              aws_access_key: "test",
+              aws_secret_key: "test",
+              signer: :v2
+            )
+            policy = nil
+            post.build { |p| p.expiration(Time.now); policy = p }
+
+            policy.should be_a(Policy)
+            policy.as(Policy).fields["Signature"].should eq("vI0Km7fxOL7B9BunXFKM2/GvS1A=")
+          end
+
+          it "yields the signed v4 policy" do
+            post = Post.new(
+              region: "us-east-1",
+              aws_access_key: "test",
+              aws_secret_key: "test"
+            )
+            policy = nil
+            post.build { |p| p.expiration(Time.now); policy = p }
+
+            policy.should be_a(Policy)
+            policy.as(Policy).fields["x-amz-signature"].should eq("7dc0bf8fe1dcc2344f8ceaf3148a8898fbac6f074ccbe4edfbfac545be693add")
           end
         end
       end

--- a/spec/awscr-s3/presigned/url_spec.cr
+++ b/spec/awscr-s3/presigned/url_spec.cr
@@ -4,6 +4,17 @@ module Awscr
   module S3
     module Presigned
       describe Url do
+        it "allows signer versions" do
+          options = Url::Options.new(
+            region: "ap-northeast-1",
+            aws_access_key: "AKIAIOSFODNN7EXAMPLE",
+            aws_secret_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            bucket: "examplebucket",
+            object: "/test.txt",
+            signer: :v2
+          )
+        end
+
         it "uses region specific hosts" do
           options = Url::Options.new(
             region: "ap-northeast-1",
@@ -47,7 +58,24 @@ module Awscr
         end
 
         describe "get" do
-          it "generates a correct url" do
+          it "generates correct url for v2" do
+            time = Time.epoch(1)
+            Timecop.freeze(time)
+              options = Url::Options.new(
+                region: "us-east-1",
+                aws_access_key: "AKIAIOSFODNN7EXAMPLE",
+                aws_secret_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                bucket: "examplebucket",
+                object: "/test.txt",
+                signer: :v2
+              )
+              url = Url.new(options)
+
+              url.for(:get)
+                 .should eq("https://s3.amazonaws.com/examplebucket/test.txt?Expires=86401&AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Signature=KP7uBvqYauy%2Fzj1Rb9LgL7e87VY%3D")
+          end
+
+          it "generates a correct url for v4" do
             Timecop.freeze(Time.new(2013, 5, 24)) do
               options = Url::Options.new(
                 region: "us-east-1",

--- a/spec/awscr-s3/signer_factory_spec.cr
+++ b/spec/awscr-s3/signer_factory_spec.cr
@@ -1,0 +1,21 @@
+require "../spec_helper"
+
+module Awscr::S3
+  describe SignerFactory do
+    it "can return v2 signers" do
+      signer = SignerFactory.get("region", "key", "secrety", version: :v2)
+      signer.should be_a(Awscr::Signer::Signers::V2)
+    end
+
+    it "can return v4 signers" do
+      signer = SignerFactory.get("region", "key", "secrety", version: :v4)
+      signer.should be_a(Awscr::Signer::Signers::V4)
+    end
+
+    it "raises on invalid version" do
+      expect_raises do
+        SignerFactory.get("region", "key", "secrety", version: :v1)
+      end
+    end
+  end
+end

--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -15,7 +15,7 @@ module Awscr::S3
       end
     end
 
-    def initialize(@signer : Awscr::Signer::Signers::V4,
+    def initialize(@signer : Awscr::Signer::Signers::Interface,
                    @region : String = standard_us_region,
                    @custom_endpoint : String? = nil)
       @http = HTTP::Client.new(endpoint)

--- a/src/awscr-s3/presigned/form.cr
+++ b/src/awscr-s3/presigned/form.cr
@@ -23,8 +23,8 @@ module Awscr
         #   form.condition("success_action_status", "201")
         # end
         # ```
-        def self.build(region, aws_access_key, aws_secret_key, &block)
-          post = Post.new(region, aws_access_key, aws_secret_key)
+        def self.build(region, aws_access_key, aws_secret_key, signer = :v4, &block)
+          post = Post.new(region, aws_access_key, aws_secret_key, signer)
           post.build do |p|
             yield p
           end

--- a/src/awscr-s3/presigned/url_options.cr
+++ b/src/awscr-s3/presigned/url_options.cr
@@ -39,7 +39,20 @@ module Awscr
 
           def initialize(@aws_access_key, @aws_secret_key, @region,
                          @object, @bucket, @expires = 86_400, @host_name = nil,
-                         @additional_options = {} of String => String)
+                         @additional_options = {} of String => String, @signer = :v4)
+          end
+
+          def signer_version
+            @signer
+          end
+
+          def signer
+            SignerFactory.get(
+              version: @signer,
+              region: @region,
+              aws_access_key: @aws_access_key,
+              aws_secret_key: @aws_secret_key
+            )
           end
         end
       end

--- a/src/awscr-s3/signer_factory.cr
+++ b/src/awscr-s3/signer_factory.cr
@@ -1,0 +1,27 @@
+module Awscr
+  module S3
+    class SignerFactory
+      def self.get(region : String, aws_access_key : String,
+                   aws_secret_key : String, version : Symbol)
+        case version
+        when :v4
+          Awscr::Signer::Signers::V4.new(
+            service: "s3",
+            region: region,
+            aws_access_key: aws_access_key,
+            aws_secret_key: aws_secret_key
+          )
+        when :v2
+          Awscr::Signer::Signers::V2.new(
+            service: "s3",
+            region: region,
+            aws_access_key: aws_access_key,
+            aws_secret_key: aws_secret_key
+          )
+        else
+          raise "Unknown signer version: #{version}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
First pass at changes required to support the V2 signing feature from the signing shard

- Allows version 2 signing for `Client`
- Allows version 2 signing for `Presigned::Url`

Missing `Presigned::Form` v2 support
