### PR TITLE
Specify object after bucket name

### DIFF
--- a/src/awscr-s3/presigned/url.cr
+++ b/src/awscr-s3/presigned/url.cr
@@ -48,7 +48,7 @@ module Awscr
 
           request = HTTP::Request.new(
             method,
-            "/#{@options.bucket}#{@options.object}",
+            "/#{@options.bucket}/#{@options.object}",
             headers,
             body
           )


### PR DESCRIPTION
Currently, a presigned url is built such that the object name is appended to the bucket, rather than being specified as part of the bucket. For instance, if I want to upload a file `text.txt` to a bucket `test`, a URL `https://s3-us-west-2.amazonaws.com/testtext.txt` is generated. This adds a slash between the bucket and object so it becomes `https://s3-us-west-2.amazonaws.com/test/text.txt`.