### PR TITLE
add support for getting objects over body_io for streaming

### DIFF
--- a/spec/awscr-s3/http_spec.cr
+++ b/spec/awscr-s3/http_spec.cr
@@ -74,6 +74,34 @@ module Awscr::S3
           http.get("/sup")
         end
       end
+
+      context "with body_io" do
+        pending "handles aws specific errors" do
+          WebMock.stub(:get, "http://s3.amazonaws.com/sup?")
+            .to_return(status: 404, body: ERROR_BODY)
+
+          http = Http.new(SIGNER)
+
+          expect_raises Http::ServerError, "NoSuchKey: The resource you requested does not exist" do
+            http.get("/sup") do |response|
+              pp response
+            end
+          end
+        end
+
+        pending "handles bad responses" do
+          WebMock.stub(:get, "http://s3.amazonaws.com/sup?")
+            .to_return(status: 404)
+
+          http = Http.new(SIGNER)
+
+          expect_raises Http::ServerError do
+            http.get("/sup") do |response|
+              pp response
+            end
+          end
+        end
+      end
     end
 
     describe "head" do

--- a/src/awscr-s3/client.cr
+++ b/src/awscr-s3/client.cr
@@ -245,6 +245,20 @@ module Awscr::S3
       Response::GetObjectOutput.from_response(resp)
     end
 
+    # Get the contents of an object in a bucket as an IO object
+    #
+    # ```
+    # client = Client.new("region", "key", "secret")
+    # client.get_object("bucket1", "obj") do |resp|
+    #   IO.copy(resp.body.as(IO), STDOUT) # => "MY DATA"
+    # end
+    # ```
+    def get_object(bucket, object : String)
+      http.get("/#{bucket}/#{object}") do |resp|
+        yield Response::GetObjectOutput.from_response(resp)
+      end
+    end
+
     # List all the items in a bucket
     #
     # ```

--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -9,7 +9,7 @@ module Awscr::S3
     class ServerError < Exception
       # Creates a `ServerError` from an `HTTP::Client::Response`
       def self.from_response(response)
-        xml = XML.new(response.body)
+        xml = XML.new(response.body || response.body_io)
 
         code = xml.string("//Error/Code")
         message = xml.string("//Error/Message")
@@ -86,11 +86,26 @@ module Awscr::S3
       handle_response!(resp)
     end
 
+    # Issue a GET request to the *path*
+    #
+    # ```
+    # http = Http.new(signer)
+    # http.get("/") do |resp|
+    #   pp resp
+    # end
+    # ```
+    def get(path)
+      @http.get(path) do |resp|
+        handle_response!(resp)
+        yield resp
+      end
+    end
+
     # :nodoc:
     private def handle_response!(response)
       return response if (200..299).includes?(response.status_code)
 
-      if !response.body.empty?
+      if response.body_io? || !response.body?.try(&.empty?)
         raise ServerError.from_response(response)
       else
         raise ServerError.new("server error: #{response.status_code}")

--- a/src/awscr-s3/responses/get_object_output.cr
+++ b/src/awscr-s3/responses/get_object_output.cr
@@ -8,7 +8,7 @@ module Awscr::S3::Response
     # Create a `GetObjectOutput` response from an
     # `HTTP::Client::Response` object
     def self.from_response(response)
-      new(response.body)
+      new(response.body || response.body_io)
     end
 
     def initialize(@body : IO | String)

--- a/src/awscr-s3/xml.cr
+++ b/src/awscr-s3/xml.cr
@@ -49,7 +49,7 @@ module Awscr::S3
       end
     end
 
-    def initialize(xml : String)
+    def initialize(xml : String | IO)
       @xml = NamespacedNode.new(::XML.parse(xml))
     end
 


### PR DESCRIPTION
Especially useful for handling large files not fitting in RAM. Note the pending specs, since the Webmock lib doesn't support body_io yet. See [manastech/webmock.cr/pull/27](/manastech/webmock.cr/pull/27)