### PR TITLE
use response.body? to check if body exists in string form

### DIFF
--- a/src/awscr-s3/responses/get_object_output.cr
+++ b/src/awscr-s3/responses/get_object_output.cr
@@ -8,7 +8,7 @@ module Awscr::S3::Response
     # Create a `GetObjectOutput` response from an
     # `HTTP::Client::Response` object
     def self.from_response(response)
-      new(response.body || response.body_io)
+      new(response.body? || response.body_io)
     end
 
     def initialize(@body : IO | String)


### PR DESCRIPTION
Sorry, this slipped through with the last pull request. body is always truthy, also for `HTTP::Client#get` in the block form which is why we need to use `body?` in `from_response`