### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ resp.success? # => true
 ## **Get Object**
 
 ```crystal
-resp = client.put_object("bucket_name", "object_key")
+resp = client.get_object("bucket_name", "object_key")
 resp.body # => myobjectbody
 ```
 


### PR DESCRIPTION
Short one-line fix. For **Get Object** in the README, it should be:
```crystal
resp = client.get_object("bucket_name", "object_key")
```