### PR TITLE
Allow key_count to be empty

### DIFF
--- a/src/awscr-s3/responses/list_objects_v2.cr
+++ b/src/awscr-s3/responses/list_objects_v2.cr
@@ -24,7 +24,7 @@ module Awscr::S3::Response
         objects << Object.new(key, size, etag)
       end
 
-      new(name, prefix, key_count.to_i, max_keys.to_i, truncated == "true", token, objects)
+      new(name, prefix, key_count.to_i? || 0, max_keys.to_i, truncated == "true", token, objects)
     end
 
     # The list of obects


### PR DESCRIPTION
For `ListObjectsV2`, the `key_count` can sometimes be empty or non-existent. This is a quick fix to add a default value if it's not a valid integer.