### PR TITLE
Attach headers to GetObjectOutput

### DIFF
--- a/src/awscr-s3/responses/get_object_output.cr
+++ b/src/awscr-s3/responses/get_object_output.cr
@@ -4,14 +4,16 @@ module Awscr::S3::Response
   class GetObjectOutput
     # The body of the request object
     getter body
+    # The headers returned along with the object response
+    getter headers
 
     # Create a `GetObjectOutput` response from an
     # `HTTP::Client::Response` object
     def self.from_response(response)
-      new(response.body? || response.body_io)
+      new(response.body? || response.body_io, response.headers)
     end
 
-    def initialize(@body : IO | String)
+    def initialize(@body : IO | String, @headers : HTTP::Headers)
     end
 
     def_equals @body


### PR DESCRIPTION
Having the headers in this response object could be useful for cases where the object store has more knowledge about the object than the Crystal process (e.g. Crystal acting as a wildcard proxy to S3 to authorise requests).

I've got this current use case, as I'm effectively using S3 as my filesystem but when I wish to proxy a file back to a client I need to scan the file path for the extension so that I can set the Content-Type, which feels like a waste when it's already delivered from S3.

Any thoughts let me know, but hoping it's not a controversial one! 😄 