### PR TITLE
Add head_object method

### DIFF
--- a/src/awscr-s3/client.cr
+++ b/src/awscr-s3/client.cr
@@ -264,8 +264,8 @@ module Awscr::S3
     # ```
     # client = Client.new("region", "key", "secret")
     # resp = client.head_object("bucket1", "obj")
-    # p resp.size   # => 123
-    # p resp.status # => HTTP::Status::OK
+    # p resp.size          # => 123
+    # p resp.status        # => HTTP::Status::OK
     # p resp.last_modified # => "Wed, 19 Jun 2019 11:55:33 GMT"
     # ```
     def head_object(bucket, object : String, headers : Hash(String, String) = Hash(String, String).new)

--- a/src/awscr-s3/client.cr
+++ b/src/awscr-s3/client.cr
@@ -259,6 +259,20 @@ module Awscr::S3
       end
     end
 
+    # Get the metadata of an object in a bucket
+    #
+    # ```
+    # client = Client.new("region", "key", "secret")
+    # resp = client.head_object("bucket1", "obj")
+    # p resp.size   # => 123
+    # p resp.status # => HTTP::Status::OK
+    # p resp.last_modified # => "Wed, 19 Jun 2019 11:55:33 GMT"
+    # ```
+    def head_object(bucket, object : String, headers : Hash(String, String) = Hash(String, String).new)
+      resp = http.head("/#{bucket}/#{object}", headers: headers)
+      Response::HeadObjectOutput.from_response(resp)
+    end
+
     # List all the items in a bucket
     #
     # ```

--- a/src/awscr-s3/head_object_output.cr
+++ b/src/awscr-s3/head_object_output.cr
@@ -1,0 +1,29 @@
+require "xml"
+
+module Awscr::S3::Response
+  class HeadObjectOutput
+    # The body of the request object
+    getter status : HTTP::Status
+    getter status_message : String | Nil
+    getter headers : HTTP::Headers
+    getter content_type : String
+    getter last_modified : String
+    getter size : UInt64
+
+    # Create a `GetObjectOutput` response from an
+    # `HTTP::Client::Response` object
+    def self.from_response(response)
+      new(
+        status: response.status,
+        status_message: response.status_message,
+        headers: response.headers,
+        content_type: response.headers["Content-Type"],
+        last_modified: response.headers["Last-Modified"],
+        size: response.headers["Content-Length"].to_u64,
+      )
+    end
+
+    def initialize(@status, @status_message, @headers, @content_type, @last_modified, @size)
+    end
+  end
+end

--- a/src/awscr-s3/head_object_output.cr
+++ b/src/awscr-s3/head_object_output.cr
@@ -1,11 +1,14 @@
 module Awscr::S3::Response
   class HeadObjectOutput
+    
+    DATE_FORMAT = "%FT%T"
+    
     # The body of the request object
     getter status : HTTP::Status
     getter status_message : String | Nil
     getter headers : HTTP::Headers
     getter content_type : String
-    getter last_modified : String
+    getter last_modified : Time
     getter size : UInt64
 
     # Create a `GetObjectOutput` response from an
@@ -16,7 +19,7 @@ module Awscr::S3::Response
         status_message: response.status_message,
         headers: response.headers,
         content_type: response.headers["Content-Type"],
-        last_modified: response.headers["Last-Modified"],
+        last_modified: Time.parse(response.headers["Last-Modified"], DATE_FORMAT, Time::Location::UTC),
         size: response.headers["Content-Length"].to_u64,
       )
     end

--- a/src/awscr-s3/head_object_output.cr
+++ b/src/awscr-s3/head_object_output.cr
@@ -1,5 +1,3 @@
-require "xml"
-
 module Awscr::S3::Response
   class HeadObjectOutput
     # The body of the request object

--- a/src/awscr-s3/head_object_output.cr
+++ b/src/awscr-s3/head_object_output.cr
@@ -1,8 +1,7 @@
 module Awscr::S3::Response
   class HeadObjectOutput
-    
     DATE_FORMAT = "%a, %d %b %Y %l:%M:%S"
-    
+
     # The body of the request object
     getter status : HTTP::Status
     getter status_message : String | Nil
@@ -26,7 +25,7 @@ module Awscr::S3::Response
 
     def initialize(@status, @status_message, @headers, @content_type, @last_modified, @size)
     end
-    
+
     private def self.parse_date(date : String)
       last_modified_words = date.split(" ")
       timezone = Time::Location.local = Time::Location.load(last_modified_words.pop)

--- a/src/awscr-s3/head_object_output.cr
+++ b/src/awscr-s3/head_object_output.cr
@@ -1,7 +1,7 @@
 module Awscr::S3::Response
   class HeadObjectOutput
     
-    DATE_FORMAT = "%FT%T"
+    DATE_FORMAT = "%a, %d %b %Y %l:%M:%S"
     
     # The body of the request object
     getter status : HTTP::Status
@@ -19,12 +19,18 @@ module Awscr::S3::Response
         status_message: response.status_message,
         headers: response.headers,
         content_type: response.headers["Content-Type"],
-        last_modified: Time.parse(response.headers["Last-Modified"], DATE_FORMAT, Time::Location::UTC),
+        last_modified: self.parse_date(response.headers["Last-Modified"]),
         size: response.headers["Content-Length"].to_u64,
       )
     end
 
     def initialize(@status, @status_message, @headers, @content_type, @last_modified, @size)
+    end
+    
+    private def self.parse_date(date : String)
+      last_modified_words = date.split(" ")
+      timezone = Time::Location.local = Time::Location.load(last_modified_words.pop)
+      Time.parse(last_modified_words.join(" "), DATE_FORMAT, timezone)
     end
   end
 end


### PR DESCRIPTION
Hi,

Thanks for creating this great package.

I'm in a situation where I'd like to be able to access object meta data without fetching the files.

I thought it would be useful to add this as a method `head_object` as this is the API that AWS uses. I've also added a new response type for it.

I think it would also be nice to use Crystal's `Time` class for last_modified, but I had some trouble parsing the date format so I've left it as-is.