### PR TITLE
bump awscr-signer version to 0.6.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   awscr-signer:
     github: taylorfinnell/awscr-signer
-    version: ~> 0.5.0
+    version: ~> 0.6.0
 
 development_dependencies:
   timecop:


### PR DESCRIPTION
makes awscr-s3 work with crystal 0.30.0