### PR TITLE
Fix division operator because of Crystal 0.31.0

### DIFF
--- a/src/awscr-s3/multipart_file_uploader.cr
+++ b/src/awscr-s3/multipart_file_uploader.cr
@@ -58,7 +58,7 @@ module Awscr::S3
     end
 
     private def compute_default_part_size(source_size)
-      [(source_size / 10_000).ceil, 5 * 1024 * 1024].max
+      [(source_size // 10_000).ceil, 5 * 1024 * 1024].max
     end
 
     private def part_size(total_size, part_size, offset)


### PR DESCRIPTION
`compute_default_part_size` of `MultipartFileUploader` returns `Float64` right now on Crystal 0.31.0, on 0.30.1 it returned `Int32`:
https://github.com/taylorfinnell/awscr-s3/blob/master/src/awscr-s3/multipart_file_uploader.cr#L60

This is because of this PR:
https://github.com/crystal-lang/crystal/pull/8120

The division needs to be changed from `/` to `//` to keep the type of the right side.