### PR TITLE
Use Crystal's MIME

### DIFF
--- a/spec/awscr-s3/content_type_spec.cr
+++ b/spec/awscr-s3/content_type_spec.cr
@@ -11,12 +11,10 @@ module Awscr::S3
 
     describe "when the io is a file" do
       it "returns the correct Content-Type" do
-        ContentType::TYPES.keys.each do |ext|
-          tempfile = File.tempfile("foo", ext)
-          file = File.open(tempfile.path)
-          ContentType.get(file).should be(ContentType::TYPES[ext])
-          tempfile.delete
-        end
+        tempfile = File.tempfile("foo", ".txt")
+        file = File.open(tempfile.path)
+        ContentType.get(file).should eq("text/plain")
+        tempfile.delete
       end
     end
 
@@ -25,6 +23,17 @@ module Awscr::S3
         tempfile = File.tempfile("foo", ".spicy")
         file = File.open(tempfile.path)
         ContentType.get(file).should be(ContentType::DEFAULT)
+        tempfile.delete
+      end
+    end
+
+    describe "custom types" do
+      it "works" do
+        MIME.register(".bhutjolokia", "ouch!")
+
+        tempfile = File.tempfile("foo", ".bhutjolokia")
+        file = File.open(tempfile.path)
+        ContentType.get(file).should eq("ouch!")
         tempfile.delete
       end
     end

--- a/src/awscr-s3/content_type.cr
+++ b/src/awscr-s3/content_type.cr
@@ -1,86 +1,16 @@
+require "mime"
+
 module Awscr::S3
   # Determines the Content-Type of IO
   class ContentType
     # The default content type if one can not be determined from the filename
     DEFAULT = "binary/octet-stream"
 
-    # :nodoc:
-    TYPES = {
-      ".aac"   => "audio/aac",
-      ".abw"   => "application/x-abiword",
-      ".arc"   => "application/octet-stream",
-      ".avi"   => "video/x-msvideo",
-      ".azw"   => "application/vnd.amazon.ebook",
-      ".bin"   => "application/octet-stream",
-      ".bz"    => "application/x-bzip",
-      ".bz2"   => "application/x-bzip2",
-      ".csh"   => "application/x-csh",
-      ".css"   => "text/css",
-      ".csv"   => "text/csv",
-      ".doc"   => "application/msword",
-      ".docx"  => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      ".eot"   => "application/vnd.ms-fontobject",
-      ".epub"  => "application/epub+zip",
-      ".gif"   => "image/gif",
-      ".htm"   => "text/html",
-      ".html"  => "text/html",
-      ".ico"   => "image/x-icon",
-      ".ics"   => "text/calendar",
-      ".jar"   => "application/java-archive",
-      ".jpeg"  => "image/jpeg",
-      ".jpg"   => "image/jpeg",
-      ".js"    => "application/javascript",
-      ".json"  => "application/json",
-      ".mid"   => "audio/midi",
-      ".midi"  => "audio/midi",
-      ".mpeg"  => "video/mpeg",
-      ".mpkg"  => "application/vnd.apple.installer+xml",
-      ".odp"   => "application/vnd.oasis.opendocument.presentation",
-      ".ods"   => "application/vnd.oasis.opendocument.spreadsheet",
-      ".odt"   => "application/vnd.oasis.opendocument.text",
-      ".oga"   => "audio/ogg",
-      ".ogv"   => "video/ogg",
-      ".ogx"   => "application/ogg",
-      ".otf"   => "font/otf",
-      ".png"   => "image/png",
-      ".pdf"   => "application/pdf",
-      ".ppt"   => "application/vnd.ms-powerpoint",
-      ".pptx"  => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      ".rar"   => "application/x-rar-compressed",
-      ".rtf"   => "application/rtf",
-      ".sh"    => "application/x-sh",
-      ".svg"   => "image/svg+xml",
-      ".swf"   => "application/x-shockwave-flash",
-      ".tar"   => "application/x-tar",
-      ".tif"   => "image/tiff",
-      ".tiff"  => "image/tiff",
-      ".ts"    => "application/typescript",
-      ".ttf"   => "font/ttf",
-      ".vsd"   => "application/vnd.visio",
-      ".wav"   => "audio/x-wav",
-      ".weba"  => "audio/webm",
-      ".webm"  => "video/webm",
-      ".webp"  => "image/webp",
-      ".woff"  => "font/woff",
-      ".woff2" => "font/woff2",
-      ".xhtml" => "application/xhtml+xml",
-      ".xls"   => "application/vnd.ms-excel",
-      ".xlsx"  => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      ".xml"   => "application/xml",
-      ".xul"   => "application/vnd.mozilla.xul+xml",
-      ".zip"   => "application/zip",
-      ".3gp"   => "video/3gpp",
-      ".3g2"   => "video/3gpp2",
-      ".7z"    => "application/x-7z-compressed",
-    }
-
     # Gets a content type based on the file extesion, if there is no file
     # extension it uses the default content type
     def self.get(io : IO) : String
-      case io
-      when .responds_to?(:path)
-        extension = File.extname(io.path)
-        TYPES.fetch(extension, DEFAULT)
+      if io.responds_to?(:path)
+        MIME.from_filename(io.path, DEFAULT)
       else
         DEFAULT
       end


### PR DESCRIPTION
Use the Crystal `MIME` class so users can register more extensions and types beyond the old hardcoded list