### PR TITLE
Add ability to compare bucket name to string

### DIFF
--- a/spec/awscr-s3/bucket_spec.cr
+++ b/spec/awscr-s3/bucket_spec.cr
@@ -14,6 +14,18 @@ module Awscr::S3
       (Bucket.new("test", Time.unix(Time.local.to_unix + 123)) == bucket).should eq(false)
     end
 
+    it "has the same name as the string provided" do
+      time = Time.local
+      bucket = Bucket.new("test3", time)
+      (bucket == "test3").should eq(true)
+    end
+
+    it "has not the same name as the string provided" do 
+      time = Time.local
+      bucket = Bucket.new("test4", time)
+      (bucket == "abcdef").should eq(false)
+    end
+
     it "has a name" do
       bucket = Bucket.new("name", Time.local)
 

--- a/src/awscr-s3/bucket.cr
+++ b/src/awscr-s3/bucket.cr
@@ -13,6 +13,11 @@ module Awscr::S3
     def initialize(@name : String, @creation_time : Time, @owner : String? = nil)
     end
 
+    # Compares the name of the bucket to other
+    def ==(other : String)
+      @name == other
+    end
+
     def_equals @name, @creation_time
   end
 end


### PR DESCRIPTION
This allows to easier compare buckets. For example it is now possible to do something like this:
```crystal
buckets = client.list_buckets
if buckets.includes?("bucket_name") 
     ...
else
     ...
end
```
or other compare operations without the need to always create a bucket with the name and exact creation date.