### PR TITLE
Encode object name instead of the whole URL

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   awscr-signer:
     github: taylorfinnell/awscr-signer
-    version: ~> 0.7.0
+    version: ~> 0.8.0
 
 development_dependencies:
   timecop:

--- a/spec/awscr-s3/presigned/html_printer_spec.cr
+++ b/spec/awscr-s3/presigned/html_printer_spec.cr
@@ -55,7 +55,7 @@ module Awscr
             <input type="hidden" name="x-amz-algorithm" value="AWS4-HMAC-SHA256" /><br />
             <input type="hidden" name="x-amz-date" value="19700101T000001Z" /><br />
             <input type="hidden" name="policy" value="eyJleHBpcmF0aW9uIjoiMTk3MC0wMS0wMVQwMDowMDowMS4wMDBaIiwiY29uZGl0aW9ucyI6W3siYnVja2V0IjoidGVzdCJ9LHsieC1hbXotY3JlZGVudGlhbCI6InRlc3QvMTk3MDAxMDEvcmVnaW9uL3MzL2F3czRfcmVxdWVzdCJ9LHsieC1hbXotYWxnb3JpdGhtIjoiQVdTNC1ITUFDLVNIQTI1NiJ9LHsieC1hbXotZGF0ZSI6IjE5NzAwMTAxVDAwMDAwMVoifV19" /><br />
-            <input type="hidden" name="x-amz-signature" value="f509df9965f9cf92b77aabc6b81a6f2fd24f36d3a6daaf46e9704ef5c333ee88\" />
+            <input type="hidden" name="x-amz-signature" value="f509df9965f9cf92b77aabc6b81a6f2fd24f36d3a6daaf46e9704ef5c333ee88" />
 
             <input type="file"   name="file" /> <br />
             <input type="submit" name="submit" value="Upload" />

--- a/spec/fixtures.cr
+++ b/spec/fixtures.cr
@@ -17,7 +17,7 @@ module Fixtures
         <Location>https://s3.amazonaws.com/screensnapr-development/test</Location>
         <Bucket>screensnapr-development</Bucket>
         <Key>test</Key>
-        <ETag>\"7611c6414e4b58f22ff9f59a2c1767b7-2\"</ETag>
+        <ETag>"7611c6414e4b58f22ff9f59a2c1767b7-2"</ETag>
       </CompleteMultipartUploadResult>
     RESP_BODY
   end

--- a/src/awscr-s3/client.cr
+++ b/src/awscr-s3/client.cr
@@ -94,7 +94,7 @@ module Awscr::S3
     # ```
     def start_multipart_upload(bucket : String, object : String,
                                headers : Hash(String, String) = Hash(String, String).new)
-      resp = http.post("/#{bucket}/#{object}?uploads", headers: headers)
+      resp = http.post("/#{bucket}/#{URI.encode_www_form(object)}?uploads", headers: headers)
 
       Response::StartMultipartUpload.from_response(resp)
     end
@@ -107,8 +107,8 @@ module Awscr::S3
     # p resp.upload_id # => someid
     # ```
     def upload_part(bucket : String, object : String,
-                    upload_id : String, part_number : Int32, part : IO | String | Bytes)
-      resp = http.put("/#{bucket}/#{object}?partNumber=#{part_number}&uploadId=#{upload_id}", part)
+                    upload_id : String, part_number : Int32, part : IO | String)
+      resp = http.put("/#{bucket}/#{URI.encode_www_form(object)}?partNumber=#{part_number}&uploadId=#{upload_id}", part)
 
       Response::UploadPartOutput.new(
         resp.headers["ETag"],
@@ -141,7 +141,7 @@ module Awscr::S3
         end
       end
 
-      resp = http.post("/#{bucket}/#{object}?uploadId=#{upload_id}", body: body)
+      resp = http.post("/#{bucket}/#{URI.encode_www_form(object)}?uploadId=#{upload_id}", body: body)
       Response::CompleteMultipartUpload.from_response(resp)
     end
 
@@ -154,7 +154,7 @@ module Awscr::S3
     # p resp # => true
     # ```
     def abort_multipart_upload(bucket : String, object : String, upload_id : String)
-      resp = http.delete("/#{bucket}/#{object}?uploadId=#{upload_id}")
+      resp = http.delete("/#{bucket}/#{URI.encode_www_form(object)}?uploadId=#{upload_id}")
 
       resp.status_code == 204
     end
@@ -182,7 +182,7 @@ module Awscr::S3
     # p resp # => true
     # ```
     def delete_object(bucket, object, headers : Hash(String, String) = Hash(String, String).new)
-      resp = http.delete("/#{bucket}/#{object}", headers)
+      resp = http.delete("/#{bucket}/#{URI.encode_www_form(object)}", headers)
 
       resp.status_code == 204
     end
@@ -228,7 +228,7 @@ module Awscr::S3
     # ```
     def put_object(bucket, object : String, body : IO | String | Bytes,
                    headers : Hash(String, String) = Hash(String, String).new)
-      resp = http.put("/#{bucket}/#{object}", body, headers)
+      resp = http.put("/#{bucket}/#{URI.encode_www_form(object)}", body, headers)
 
       Response::PutObjectOutput.from_response(resp)
     end
@@ -241,7 +241,7 @@ module Awscr::S3
     # p resp.body # => "MY DATA"
     # ```
     def get_object(bucket, object : String, headers : Hash(String, String) = Hash(String, String).new)
-      resp = http.get("/#{bucket}/#{object}", headers: headers)
+      resp = http.get("/#{bucket}/#{URI.encode_www_form(object)}", headers: headers)
 
       Response::GetObjectOutput.from_response(resp)
     end
@@ -255,7 +255,7 @@ module Awscr::S3
     # end
     # ```
     def get_object(bucket, object : String, headers : Hash(String, String) = Hash(String, String).new)
-      http.get("/#{bucket}/#{object}", headers: headers) do |resp|
+      http.get("/#{bucket}/#{URI.encode_www_form(object)}", headers: headers) do |resp|
         yield Response::GetObjectStream.from_response(resp)
       end
     end
@@ -270,7 +270,7 @@ module Awscr::S3
     # p resp.last_modified # => "Wed, 19 Jun 2019 11:55:33 GMT"
     # ```
     def head_object(bucket, object : String, headers : Hash(String, String) = Hash(String, String).new)
-      resp = http.head("/#{bucket}/#{object}", headers: headers)
+      resp = http.head("/#{bucket}/#{URI.encode_www_form(object)}", headers: headers)
       Response::HeadObjectOutput.from_response(resp)
     end
 

--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -116,9 +116,19 @@ module Awscr::S3
     # :nodoc:
     private def http
       client = HTTP::Client.new(@endpoint)
-      client.before_request do |request|
-        @signer.sign(request)
+
+      # When we are using V4 we must tell the signer to skip encoding the path
+      # because we already did that
+      if (signer = @signer).is_a?(Awscr::Signer::Signers::V4)
+        client.before_request do |request|
+          signer.as(Awscr::Signer::Signers::V4).sign(request, encode_path: false)
+        end
+      else
+        client.before_request do |request|
+          signer.sign(request)
+        end
       end
+
       client
     end
   end


### PR DESCRIPTION
Fixes #34 and #60 and is based on my pull request to awscr-signer.