### PR TITLE
Fix to allow for Crystal 1.0 compatibility.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.8.1
 authors:
   - Taylor Finnell <tmfinnell@gmail.com>
 
-crystal: 0.32.0
+crystal: ">= 0.32.0"
 
 license: MIT
 

--- a/src/awscr-s3/presigned/url.cr
+++ b/src/awscr-s3/presigned/url.cr
@@ -30,7 +30,11 @@ module Awscr
 
           String.build do |str|
             str << "https://"
-            str << request.host
+            {% if compare_versions(Crystal::VERSION, "0.36.0") < 0 %}
+              str << request.host
+            {% else %}
+              str << request.hostname
+            {% end %}
             str << request.resource
           end
         end


### PR DESCRIPTION
Fixes #92

Specs pass locally on both Crystal 1.0.0, and 0.36.1

```
awscr-s3 on  crystal1.0 [!+] via 🔮 v0.36.1 took 7s
❯ crystal spec
............................................................................................................................

Finished in 678.33 milliseconds
124 examples, 0 failures, 0 errors, 0 pending

awscr-s3 on  crystal1.0 [!+] via 🔮 v0.36.1 took 6s
❯ ~/Development/crystal/crystal-1.0.0-1/bin/crystal spec
............................................................................................................................

Finished in 698.38 milliseconds
124 examples, 0 failures, 0 errors, 0 pending
```