### PR TITLE
fix(multipart file uploader): using shared http client

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: awscr-s3
-version: 0.8.3
+version: 0.8.4
 
-crystal: ">= 0.36.1, < 2.0.0"
+crystal: ">= 0.36.1"
 
 description: |
   A Crystal shard for S3 and compatible services.

--- a/spec/awscr-s3/content_type_spec.cr
+++ b/spec/awscr-s3/content_type_spec.cr
@@ -13,7 +13,7 @@ module Awscr::S3
       it "returns the correct Content-Type" do
         tempfile = File.tempfile("foo", ".txt")
         file = File.open(tempfile.path)
-        ContentType.get(file).should eq("text/plain")
+        ContentType.get(file).should eq("text/plain; charset=utf-8")
         tempfile.delete
       end
     end

--- a/spec/awscr-s3/content_type_spec.cr
+++ b/spec/awscr-s3/content_type_spec.cr
@@ -13,7 +13,7 @@ module Awscr::S3
       it "returns the correct Content-Type" do
         tempfile = File.tempfile("foo", ".txt")
         file = File.open(tempfile.path)
-        ContentType.get(file).should eq("text/plain; charset=utf-8")
+        ContentType.get(file)[0..9].should eq("text/plain")
         tempfile.delete
       end
     end

--- a/src/awscr-s3/client.cr
+++ b/src/awscr-s3/client.cr
@@ -107,9 +107,8 @@ module Awscr::S3
     # ```
     def upload_part(bucket : String, object : String,
                     upload_id : String, part_number : Int32, part : IO | String)
-      puts "uploading #{part_number}"
       resp = http.put("/#{bucket}/#{Util.encode(object)}?partNumber=#{part_number}&uploadId=#{upload_id}", part)
-      puts "completed #{part_number}"
+
       Response::UploadPartOutput.new(
         resp.headers["ETag"],
         part_number,

--- a/src/awscr-s3/client.cr
+++ b/src/awscr-s3/client.cr
@@ -33,7 +33,6 @@ module Awscr::S3
         aws_access_key: @aws_access_key,
         aws_secret_key: @aws_secret_key
       )
-      @http = Http.new(@signer, @region, @endpoint)
     end
 
     # List s3 buckets
@@ -108,8 +107,9 @@ module Awscr::S3
     # ```
     def upload_part(bucket : String, object : String,
                     upload_id : String, part_number : Int32, part : IO | String)
+      puts "uploading #{part_number}"
       resp = http.put("/#{bucket}/#{Util.encode(object)}?partNumber=#{part_number}&uploadId=#{upload_id}", part)
-
+      puts "completed #{part_number}"
       Response::UploadPartOutput.new(
         resp.headers["ETag"],
         part_number,
@@ -309,7 +309,7 @@ module Awscr::S3
 
     # :nodoc:
     private def http
-      @http
+      Http.new(@signer, @region, @endpoint)
     end
   end
 end

--- a/src/awscr-s3/file_uploader.cr
+++ b/src/awscr-s3/file_uploader.cr
@@ -33,7 +33,7 @@ module Awscr::S3
       if io.size < UPLOAD_THRESHOLD
         @client.put_object(bucket, object, io, headers)
       else
-        uploader = MultipartFileUploader.new(@client)
+        uploader = MultipartFileUploader.new(@client, @options.simultaneous_parts)
         uploader.upload(bucket, object, io, headers)
       end
       true

--- a/src/awscr-s3/file_uploader.cr
+++ b/src/awscr-s3/file_uploader.cr
@@ -11,8 +11,9 @@ module Awscr::S3
     struct Options
       # If true the uploader will automatically add a content type header
       getter with_content_types
+      getter simultaneous_parts
 
-      def initialize(@with_content_types : Bool)
+      def initialize(@with_content_types : Bool, @simultaneous_parts : Int32 = 5)
       end
     end
 

--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -148,9 +148,7 @@ module Awscr::S3
             signer.as(Awscr::Signer::Signers::V4).sign(request, encode_path: false)
           end
         else
-          client.before_request do |request|
-            signer.sign(request)
-          end
+          client.before_request { |request| signer.sign(request) }
         end
       end
     end


### PR DESCRIPTION
this resolves an issue where the HTTP client was shared and the one client was making all the requests concurrently.
The built-in http client does not support this and resulted in interlaced writes, but it did sometimes succeed. The specs succeed as they never blocked the reactor and hence never actually executed in parallel.

I've also added configuration to limit the number of parallel uploads as previously it was uploading the complete file at once which could exhaust memory.