### PR TITLE
* Add support for temporary credentials (AWS_SECURITY_TOKEN)

### DIFF
--- a/spec/awscr-s3/client_spec.cr
+++ b/spec/awscr-s3/client_spec.cr
@@ -422,7 +422,7 @@ module Awscr::S3
           .with(body: "Hello")
           .to_return(body: "", headers: {"ETag" => "etag"})
 
-        client = Client.new("", "key", "secret", "https://nyc3.digitaloceanspaces.com")
+        client = Client.new("", "key", "secret", endpoint: "https://nyc3.digitaloceanspaces.com")
         resp = client.put_object("mybucket", "object.txt", io)
 
         resp.should eq(Response::PutObjectOutput.new("etag"))
@@ -435,7 +435,7 @@ module Awscr::S3
           .with(body: "Hello")
           .to_return(body: "", headers: {"ETag" => "etag"})
 
-        client = Client.new("", "key", "secret", "http://127.0.0.1:9000")
+        client = Client.new("", "key", "secret", endpoint: "http://127.0.0.1:9000")
         resp = client.put_object("mybucket", "object.txt", io)
 
         resp.should eq(Response::PutObjectOutput.new("etag"))

--- a/src/awscr-s3/client.cr
+++ b/src/awscr-s3/client.cr
@@ -8,10 +8,22 @@ require "base64"
 module Awscr::S3
   # An S3 client for interacting with S3.
   #
-  # Creating an S3 Client
+  # Creating an S3 Client:
+  #
+  # 1) Implicitly, through the environment (AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+  #
+  # ```
+  # client = Client.new
+  # ```
+  #
+  # 2) Explicitely, by the passing the values:
   #
   # ```
   # client = Client.new("region", "key", "secret")
+  # ```
+  #
+  # ```
+  # client = Client.new("region", "key", "secret", aws_security_token: "temp-token")
   # ```
   #
   # Client with custom endpoint
@@ -26,12 +38,18 @@ module Awscr::S3
   class Client
     @signer : Awscr::Signer::Signers::Interface
 
-    def initialize(@region : String, @aws_access_key : String, @aws_secret_key : String, @endpoint : String? = nil, signer : Symbol = :v4)
+    def initialize
+      initialize(ENV["AWS_REGION"], ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"],
+        aws_security_token: ENV["AWS_SECURITY_TOKEN"]?)
+    end
+
+    def initialize(@region : String, @aws_access_key : String, @aws_secret_key : String, *, @aws_security_token : String? = nil, @endpoint : String? = nil, signer : Symbol = :v4)
       @signer = SignerFactory.get(
         version: signer,
         region: @region,
         aws_access_key: @aws_access_key,
-        aws_secret_key: @aws_secret_key
+        aws_secret_key: @aws_secret_key,
+        aws_security_token: @aws_security_token
       )
     end
 

--- a/src/awscr-s3/signer_factory.cr
+++ b/src/awscr-s3/signer_factory.cr
@@ -5,14 +5,15 @@ module Awscr
     class SignerFactory
       # Fetch and configure a signer based on a version algorithm
       def self.get(region : String, aws_access_key : String,
-                   aws_secret_key : String, version : Symbol)
+                   aws_secret_key : String, version : Symbol, aws_security_token : String? = nil)
         case version
         when :v4
           Awscr::Signer::Signers::V4.new(
             service: "s3",
             region: region,
             aws_access_key: aws_access_key,
-            aws_secret_key: aws_secret_key
+            aws_secret_key: aws_secret_key,
+            aws_security_token: aws_security_token
           )
         when :v2
           Awscr::Signer::Signers::V2.new(


### PR DESCRIPTION
* Add support for temporary credentials (AWS_SECURITY_TOKEN)
* Support configuring an S3 Client with the environment variables

I tried to make the naming more consistent, which resulted in a small change in [awscr-signer](https://github.com/taylorfinnell/awscr-signer), but I don't have a strong opinion on the naming (-> https://github.com/taylorfinnell/awscr-signer/pull/61).

Now the following code should work if the environment variables are set:

```crystal
require "awscr-s3"

client = Awscr::S3::Client.new
puts client.list_buckets.buckets
```

fixes #105