### PR TITLE
Fix Awscr::S3::Response::HeadObjectOutput.meta method

### DIFF
--- a/src/awscr-s3/responses/head_object_output.cr
+++ b/src/awscr-s3/responses/head_object_output.cr
@@ -40,7 +40,7 @@ module Awscr::S3::Response
 
     def meta : Hash(String, String)
       meta = {} of String => String
-      response.headers.each do |k, v|
+      headers.each do |k, v|
         next unless k.starts_with?("x-amz-meta-")
         meta[k.lchop("x-amz-meta-")] = v.first
       end


### PR DESCRIPTION
Bug fix for:

```
In lib/awscr-s3/src/awscr-s3/responses/head_object_output.cr:43:7                                                                  
                                                                                                                                   
 43 | response.headers.each do |k, v|                                                                                              
      ^-------                                                                                                                     
Error: undefined local variable or method 'response' for Awscr::S3::Response::HeadObjectOutput                                     
```

Thanks! :heart: 