### PR TITLE
Migrating more code to use the new session key API

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -19,10 +19,10 @@ dependencies:
 development_dependencies:
   timecop:
     github: crystal-community/timecop.cr
-    version: ~> 0.4.0
+    version: 0.5.0
   webmock:
     github: manastech/webmock.cr
     branch: master
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.13.0
+    version: 1.6.1

--- a/src/awscr-s3/presigned/form.cr
+++ b/src/awscr-s3/presigned/form.cr
@@ -24,8 +24,17 @@ module Awscr
         #   form.condition("success_action_status", "201")
         # end
         # ```
-        def self.build(region, aws_access_key, aws_secret_key, signer = :v4, &block)
-          post = Post.new(region, aws_access_key, aws_secret_key, signer)
+        def self.build(region : String, aws_access_key : String, aws_secret_key : String, aws_session_key : String? = nil, signer = :v4, &block)
+          post = Post.new(region, aws_access_key, aws_secret_key, aws_session_key, signer)
+          post.build do |p|
+            yield p
+          end
+          new(post, HTTP::Client.new(URI.parse(post.url)))
+        end
+
+        @[Deprecated("Use `#build(region : String, aws_access_key : String, aws_secret_key : String, aws_session_key : String? = nil, signer : Symbol = :v4, &block)` instead")]
+        def self.build(region : String, aws_access_key : String, aws_secret_key : String, signer = :v4, &block)
+          post = Post.new(region, aws_access_key, aws_secret_key, nil, signer)
           post.build do |p|
             yield p
           end

--- a/src/awscr-s3/presigned/form.cr
+++ b/src/awscr-s3/presigned/form.cr
@@ -24,7 +24,7 @@ module Awscr
         #   form.condition("success_action_status", "201")
         # end
         # ```
-        def self.build(region : String, aws_access_key : String, aws_secret_key : String, aws_session_key : String? = nil, signer = :v4, &block)
+        def self.build(region : String, aws_access_key : String, aws_secret_key : String, aws_session_key : String? = nil, signer : Symbol = :v4, &block)
           post = Post.new(region, aws_access_key, aws_secret_key, aws_session_key, signer)
           post.build do |p|
             yield p

--- a/src/awscr-s3/presigned/post.cr
+++ b/src/awscr-s3/presigned/post.cr
@@ -7,9 +7,17 @@ module Awscr
       # for object uploading.
       class Post
         def initialize(@region : String, @aws_access_key : String,
-                       @aws_secret_key : String, @signer : Symbol = :v4)
+                       @aws_secret_key : String, @aws_session_key : String? = nil,
+                       @signer : Symbol = :v4)
           @policy = Policy.new
         end
+
+        @[Deprecated("Use `#initialize(region : String, aws_access_key : String, aws_secret_key : String, aws_session_key : String? = nil, signer : Symbol = :v4)` instead")]
+        def initialize(region : String, aws_access_key : String,
+                       aws_secret_key : String, signer : Symbol = :v4)
+          initialize(region, aws_access_key, aws_secret_key, nil, signer)
+        end
+
 
         # Build a post object by adding fields
         def build(&block)
@@ -85,7 +93,8 @@ module Awscr
             version: @signer,
             region: @region,
             aws_access_key: @aws_access_key,
-            aws_secret_key: @aws_secret_key
+            aws_secret_key: @aws_secret_key,
+            aws_session_key: @aws_session_key,
           )
         end
       end

--- a/src/awscr-s3/signer_factory.cr
+++ b/src/awscr-s3/signer_factory.cr
@@ -6,7 +6,7 @@ module Awscr
       # Fetch and configure a signer based on a version algorithm
       def self.get(region : String, aws_access_key : String,
                    aws_secret_key : String, version : Symbol,
-                   aws_session_key : String?)
+                   aws_session_key : String? = nil)
         case version
         when :v4
           Awscr::Signer::Signers::V4.new(


### PR DESCRIPTION
Fixing compile errors in tests by migrating more code to use the new session key API. Two tests are still failing, but it should be closer with these changes.