### PR TITLE
Fixed an overflow when files were listed that are above 2G

### DIFF
--- a/src/awscr-s3/object.cr
+++ b/src/awscr-s3/object.cr
@@ -13,7 +13,7 @@ module Awscr::S3
     # The time string the `Object` was last modifed
     getter last_modified
 
-    def initialize(@key : String, @size : Int32, @etag : String, @last_modified : Time)
+    def initialize(@key : String, @size : Int64, @etag : String, @last_modified : Time)
     end
 
     def_equals @key, @size, @etag, @last_modified

--- a/src/awscr-s3/responses/list_objects_v2.cr
+++ b/src/awscr-s3/responses/list_objects_v2.cr
@@ -21,7 +21,7 @@ module Awscr::S3::Response
       objects = [] of Object
       xml.array("ListBucketResult/Contents") do |object|
         key = object.string("Key")
-        size = object.string("Size").to_i
+        size = object.string("Size").to_i64
         etag = object.string("ETag")
         last_modified = Time.parse(object.string("LastModified"), DATE_FORMAT, Time::Location::UTC)
 


### PR DESCRIPTION
File sizes can exceed the range of `Int32`, resulting in errors like that:

```
Unhandled exception: Invalid Int32: "2305083320" (ArgumentError)
  from /usr/lib/crystal/string.cr:438:83 in 'to_i32'
  from /usr/lib/crystal/string.cr:349:5 in '__crystal_main'
  from /usr/lib/crystal/crystal/main.cr:129:5 in 'main'
  from /usr/lib/libc.so.6 in '??'
  from /usr/lib/libc.so.6 in '__libc_start_main'
```