### PR TITLE
tests: Scope before_each to the local context

### DIFF
--- a/spec/awscr-s3/presigned/html_printer_spec.cr
+++ b/spec/awscr-s3/presigned/html_printer_spec.cr
@@ -4,12 +4,8 @@ module Awscr
   module S3
     module Presigned
       describe HtmlPrinter do
-        Spec.before_each do
+        before_each do
           Timecop.freeze(Time.unix(1))
-        end
-
-        Spec.after_each do
-          Timecop.return
         end
 
         it "generates the same html each call" do

--- a/spec/awscr-s3/presigned/post_spec.cr
+++ b/spec/awscr-s3/presigned/post_spec.cr
@@ -4,12 +4,8 @@ module Awscr
   module S3
     module Presigned
       describe Post do
-        Spec.before_each do
+        before_each do
           Timecop.freeze(Time.unix(1))
-        end
-
-        Spec.after_each do
-          Timecop.return
         end
 
         describe "valid?" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,4 +7,8 @@ Spec.before_each do
   WebMock.reset
 end
 
+Spec.after_each do
+  Timecop.return
+end
+
 require "../src/awscr-s3"


### PR DESCRIPTION
Currently, `Spec.before_each` applies hooks globally to all tests. 
Switching to `before_each` ensures hooks run only within the current example group,
improving test isolation.
