### PR TITLE
fixed: retries needs to be incremented to avoid infinite retries

### DIFF
--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -103,6 +103,7 @@ module Awscr::S3
       rescue ex : IO::Error
         raise ex if retries > 2
         @client = nil
+        retries += 1
       end
     end
 


### PR DESCRIPTION
Matches also the error handling pattern of the block-free version of `exec`