### PR TITLE
Move endpoint to client and expose it

### DIFF
--- a/spec/awscr-s3/client_spec.cr
+++ b/spec/awscr-s3/client_spec.cr
@@ -9,6 +9,44 @@ module Awscr::S3
       Client.new("adasd", "adasd", "adad", signer: :v2)
     end
 
+    describe "region" do
+      it "sets the region to the provided value" do
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        client.region.should eq "us-east-1"
+
+        client = Client.new("custom-region", "some_access_key", "some_secret_key")
+
+        client.region.should eq "custom-region"
+      end
+    end
+
+    describe "endpoint" do
+      it "sets the correct endpoint" do
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        client.endpoint.should eq "https://s3.amazonaws.com/"
+      end
+
+      it "sets the correct endpoint with a defined region" do
+        client = Client.new("eu-west-1", "some_access_key", "some_secret_key")
+
+        client.endpoint.should eq "https://s3-eu-west-1.amazonaws.com/"
+      end
+
+      it "can set a custom endpoint" do
+        client = Client.new("eu-west-1", "some_access_key", "some_secret_key", endpoint: "https://nyc3.digitaloceanspaces.com")
+
+        client.endpoint.should eq "https://nyc3.digitaloceanspaces.com/"
+      end
+
+      it "can set a custom endpoint with a port" do
+        client = Client.new("eu-west-1", "some_access_key", "some_secret_key", endpoint: "http://127.0.0.1:9000")
+
+        client.endpoint.should eq "http://127.0.0.1:9000/"
+      end
+    end
+
     describe "batch_delete" do
       it "can can fail to delete items" do
         xml = <<-XML

--- a/spec/awscr-s3/client_spec.cr
+++ b/spec/awscr-s3/client_spec.cr
@@ -25,25 +25,25 @@ module Awscr::S3
       it "sets the correct endpoint" do
         client = Client.new("us-east-1", "some_access_key", "some_secret_key")
 
-        client.endpoint.should eq "https://s3.amazonaws.com/"
+        client.endpoint.to_s.should eq "https://s3.amazonaws.com"
       end
 
       it "sets the correct endpoint with a defined region" do
         client = Client.new("eu-west-1", "some_access_key", "some_secret_key")
 
-        client.endpoint.should eq "https://s3-eu-west-1.amazonaws.com/"
+        client.endpoint.to_s.should eq "https://s3-eu-west-1.amazonaws.com"
       end
 
       it "can set a custom endpoint" do
         client = Client.new("eu-west-1", "some_access_key", "some_secret_key", endpoint: "https://nyc3.digitaloceanspaces.com")
 
-        client.endpoint.should eq "https://nyc3.digitaloceanspaces.com/"
+        client.endpoint.to_s.should eq "https://nyc3.digitaloceanspaces.com"
       end
 
       it "can set a custom endpoint with a port" do
         client = Client.new("eu-west-1", "some_access_key", "some_secret_key", endpoint: "http://127.0.0.1:9000")
 
-        client.endpoint.should eq "http://127.0.0.1:9000/"
+        client.endpoint.to_s.should eq "http://127.0.0.1:9000"
       end
     end
 

--- a/spec/awscr-s3/http_spec.cr
+++ b/spec/awscr-s3/http_spec.cr
@@ -24,6 +24,10 @@ module Awscr::S3
         http = Http.new(SIGNER, client.endpoint)
 
         http.get("/").status_code.should eq 200
+
+        http = Http.new(SIGNER)
+
+        http.get("https://s3.amazonaws.com/").status_code.should eq 200
       end
 
       it "sets the correct endpoint with a defined region" do
@@ -35,6 +39,9 @@ module Awscr::S3
         http = Http.new(SIGNER, client.endpoint)
 
         http.get("/").status_code.should eq 200
+
+        http = Http.new(SIGNER, "eu-west-1")
+        http.get("https://s3-eu-west-1.amazonaws.com/").status_code.should eq 200
       end
 
       it "can set a custom endpoint" do
@@ -46,6 +53,9 @@ module Awscr::S3
         http = Http.new(SIGNER, client.endpoint)
 
         http.get("/").status_code.should eq 200
+
+        http = Http.new(SIGNER, custom_endpoint: "https://nyc3.digitaloceanspaces.com")
+        http.get("https://nyc3.digitaloceanspaces.com").status_code.should eq 200
       end
 
       it "can set a custom endpoint with a port" do
@@ -55,6 +65,10 @@ module Awscr::S3
         client = Client.new("us-east-1", "some_access_key", "some_secret_key", endpoint: "http://127.0.0.1:9000")
 
         http = Http.new(SIGNER, client.endpoint)
+
+        http.get("/").status_code.should eq 200
+
+        http = Http.new(SIGNER, custom_endpoint: "http://127.0.0.1:9000")
 
         http.get("/").status_code.should eq 200
       end
@@ -72,6 +86,12 @@ module Awscr::S3
         expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
           http.get("/sup")
         end
+
+        http = Http.new(SIGNER)
+
+        expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
+          http.get("/sup")
+        end
       end
 
       it "handles bad responses" do
@@ -81,6 +101,12 @@ module Awscr::S3
         client = Client.new("us-east-1", "some_access_key", "some_secret_key")
 
         http = Http.new(SIGNER, client.endpoint)
+
+        expect_raises S3::Exception do
+          http.get("/sup")
+        end
+
+        http = Http.new(SIGNER)
 
         expect_raises S3::Exception do
           http.get("/sup")
@@ -99,6 +125,12 @@ module Awscr::S3
           expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
             http.get("/sup")
           end
+
+          http = Http.new(SIGNER)
+
+          expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
+            http.get("/sup")
+          end
         end
 
         it "handles bad responses" do
@@ -108,6 +140,12 @@ module Awscr::S3
           client = Client.new("us-east-1", "some_access_key", "some_secret_key")
 
           http = Http.new(SIGNER, client.endpoint)
+
+          expect_raises S3::Exception do
+            http.get("/sup")
+          end
+
+          http = Http.new(SIGNER)
 
           expect_raises S3::Exception do
             http.get("/sup")
@@ -128,6 +166,12 @@ module Awscr::S3
         expect_raises S3::Exception, "The resource you requested does not exist" do
           http.head("/")
         end
+
+        http = Http.new(SIGNER)
+
+        expect_raises S3::Exception, "The resource you requested does not exist" do
+          http.head("/")
+        end
       end
 
       it "handles bad responses" do
@@ -137,6 +181,12 @@ module Awscr::S3
         client = Client.new("us-east-1", "some_access_key", "some_secret_key")
 
         http = Http.new(SIGNER, client.endpoint)
+
+        expect_raises S3::Exception do
+          http.head("/")
+        end
+
+        http = Http.new(SIGNER)
 
         expect_raises S3::Exception do
           http.head("/")
@@ -156,6 +206,12 @@ module Awscr::S3
         expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
           http.put("/", "")
         end
+
+        http = Http.new(SIGNER)
+
+        expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
+          http.put("/", "")
+        end
       end
 
       it "handles bad responses" do
@@ -165,6 +221,12 @@ module Awscr::S3
         client = Client.new("us-east-1", "some_access_key", "some_secret_key")
 
         http = Http.new(SIGNER, client.endpoint)
+
+        expect_raises S3::Exception do
+          http.put("/", "")
+        end
+
+        http = Http.new(SIGNER)
 
         expect_raises S3::Exception do
           http.put("/", "")
@@ -180,6 +242,9 @@ module Awscr::S3
 
         http = Http.new(SIGNER, client.endpoint)
         http.put("/document", "abcd")
+
+        http = Http.new(SIGNER)
+        http.put("/document", "abcd")
       end
 
       it "passes additional headers, when provided" do
@@ -190,6 +255,9 @@ module Awscr::S3
         client = Client.new("us-east-1", "some_access_key", "some_secret_key")
 
         http = Http.new(SIGNER, client.endpoint)
+        http.put("/document", "abcd", {"x-amz-meta-name" => "document"})
+
+        http = Http.new(SIGNER)
         http.put("/document", "abcd", {"x-amz-meta-name" => "document"})
       end
     end
@@ -215,6 +283,12 @@ module Awscr::S3
         expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
           http.post("/")
         end
+
+        http = Http.new(SIGNER)
+
+        expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
+          http.post("/")
+        end
       end
 
       it "handles bad responses" do
@@ -224,6 +298,12 @@ module Awscr::S3
         client = Client.new("us-east-1", "some_access_key", "some_secret_key")
 
         http = Http.new(SIGNER, client.endpoint)
+
+        expect_raises S3::Exception do
+          http.post("/")
+        end
+
+        http = Http.new(SIGNER)
 
         expect_raises S3::Exception do
           http.post("/")
@@ -252,6 +332,12 @@ module Awscr::S3
         expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
           http.delete("/")
         end
+
+        http = Http.new(SIGNER)
+
+        expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
+          http.delete("/")
+        end
       end
 
       it "handles bad responses" do
@@ -261,6 +347,12 @@ module Awscr::S3
         client = Client.new("us-east-1", "some_access_key", "some_secret_key")
 
         http = Http.new(SIGNER, client.endpoint)
+
+        expect_raises S3::Exception do
+          http.delete("/")
+        end
+
+        http = Http.new(SIGNER)
 
         expect_raises S3::Exception do
           http.delete("/")

--- a/spec/awscr-s3/http_spec.cr
+++ b/spec/awscr-s3/http_spec.cr
@@ -19,7 +19,9 @@ module Awscr::S3
         WebMock.stub(:get, "https://s3.amazonaws.com/")
           .to_return(status: 200)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         http.get("/").status_code.should eq 200
       end
@@ -28,7 +30,9 @@ module Awscr::S3
         WebMock.stub(:get, "https://s3-eu-west-1.amazonaws.com/")
           .to_return(status: 200)
 
-        http = Http.new(SIGNER, "eu-west-1")
+        client = Client.new("eu-west-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         http.get("/").status_code.should eq 200
       end
@@ -37,7 +41,9 @@ module Awscr::S3
         WebMock.stub(:get, "https://nyc3.digitaloceanspaces.com")
           .to_return(status: 200)
 
-        http = Http.new(SIGNER, custom_endpoint: "https://nyc3.digitaloceanspaces.com")
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key", endpoint: "https://nyc3.digitaloceanspaces.com")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         http.get("/").status_code.should eq 200
       end
@@ -46,7 +52,9 @@ module Awscr::S3
         WebMock.stub(:get, "http://127.0.0.1:9000")
           .to_return(status: 200)
 
-        http = Http.new(SIGNER, custom_endpoint: "http://127.0.0.1:9000")
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key", endpoint: "http://127.0.0.1:9000")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         http.get("/").status_code.should eq 200
       end
@@ -57,7 +65,9 @@ module Awscr::S3
         WebMock.stub(:get, "https://s3.amazonaws.com/sup?")
           .to_return(status: 404, body: ERROR_BODY)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
           http.get("/sup")
@@ -68,7 +78,9 @@ module Awscr::S3
         WebMock.stub(:get, "https://s3.amazonaws.com/sup?")
           .to_return(status: 404)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         expect_raises S3::Exception do
           http.get("/sup")
@@ -80,7 +92,9 @@ module Awscr::S3
           WebMock.stub(:get, "https://s3.amazonaws.com/sup?")
             .to_return(status: 404, body: ERROR_BODY)
 
-          http = Http.new(SIGNER)
+          client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+          http = Http.new(SIGNER, client.endpoint)
 
           expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
             http.get("/sup")
@@ -91,7 +105,9 @@ module Awscr::S3
           WebMock.stub(:get, "https://s3.amazonaws.com/sup?")
             .to_return(status: 404)
 
-          http = Http.new(SIGNER)
+          client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+          http = Http.new(SIGNER, client.endpoint)
 
           expect_raises S3::Exception do
             http.get("/sup")
@@ -105,7 +121,9 @@ module Awscr::S3
         WebMock.stub(:head, "https://s3.amazonaws.com/?")
           .to_return(status: 404, body: ERROR_BODY)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         expect_raises S3::Exception, "The resource you requested does not exist" do
           http.head("/")
@@ -116,7 +134,9 @@ module Awscr::S3
         WebMock.stub(:head, "https://s3.amazonaws.com/?")
           .to_return(status: 404)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         expect_raises S3::Exception do
           http.head("/")
@@ -129,7 +149,9 @@ module Awscr::S3
         WebMock.stub(:put, "https://s3.amazonaws.com/?")
           .to_return(status: 404, body: ERROR_BODY)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
           http.put("/", "")
@@ -140,7 +162,9 @@ module Awscr::S3
         WebMock.stub(:put, "https://s3.amazonaws.com/?")
           .to_return(status: 404)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         expect_raises S3::Exception do
           http.put("/", "")
@@ -152,7 +176,9 @@ module Awscr::S3
           .with(body: "abcd", headers: {"Content-Length" => "4"})
           .to_return(status: 200)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
         http.put("/document", "abcd")
       end
 
@@ -161,7 +187,9 @@ module Awscr::S3
           .with(body: "abcd", headers: {"Content-Length" => "4", "x-amz-meta-name" => "document"})
           .to_return(status: 200)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
         http.put("/document", "abcd", {"x-amz-meta-name" => "document"})
       end
     end
@@ -171,14 +199,18 @@ module Awscr::S3
         WebMock.stub(:post, "https://s3.amazonaws.com/?")
           .with(headers: {"x-amz-meta-name" => "document"})
 
-        Http.new(SIGNER).post("/", headers: {"x-amz-meta-name" => "document"})
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        Http.new(SIGNER, client.endpoint).post("/", headers: {"x-amz-meta-name" => "document"})
       end
 
       it "handles aws specific errors" do
         WebMock.stub(:post, "https://s3.amazonaws.com/?")
           .to_return(status: 404, body: ERROR_BODY)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
           http.post("/")
@@ -189,7 +221,9 @@ module Awscr::S3
         WebMock.stub(:post, "https://s3.amazonaws.com/?")
           .to_return(status: 404)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         expect_raises S3::Exception do
           http.post("/")
@@ -202,14 +236,18 @@ module Awscr::S3
         WebMock.stub(:delete, "https://s3.amazonaws.com/?")
           .with(headers: {"x-amz-mfa" => "123456"})
 
-        Http.new(SIGNER).delete("/", headers: {"x-amz-mfa" => "123456"})
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        Http.new(SIGNER, client.endpoint).delete("/", headers: {"x-amz-mfa" => "123456"})
       end
 
       it "handles aws specific errors" do
         WebMock.stub(:delete, "https://s3.amazonaws.com/?")
           .to_return(status: 404, body: ERROR_BODY)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         expect_raises S3::NoSuchKey, "The resource you requested does not exist" do
           http.delete("/")
@@ -220,7 +258,9 @@ module Awscr::S3
         WebMock.stub(:delete, "https://s3.amazonaws.com/?")
           .to_return(status: 404)
 
-        http = Http.new(SIGNER)
+        client = Client.new("us-east-1", "some_access_key", "some_secret_key")
+
+        http = Http.new(SIGNER, client.endpoint)
 
         expect_raises S3::Exception do
           http.delete("/")

--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -4,10 +4,19 @@ require "uri"
 
 module Awscr::S3
   class Http
+    @[Deprecated("Use `Http.new(signer, endpoint)` instead")]
+    def initialize(@signer : Awscr::Signer::Signers::Interface,
+                   @region : String = standard_us_region,
+                   @custom_endpoint : String? = nil)
+      @endpoint = endpoint
+    end
+
     def initialize(
       @signer : Awscr::Signer::Signers::Interface,
       @endpoint : URI,
     )
+      @region = nil
+      @custom_endpoint = nil
     end
 
     @client : HTTP::Client?
@@ -115,6 +124,23 @@ module Awscr::S3
       else
         raise S3::Exception.new("server error: #{response.status_code}")
       end
+    end
+
+    # :nodoc:
+    private def endpoint : URI
+      return URI.parse(@custom_endpoint.to_s) if @custom_endpoint
+      return default_endpoint if @region == standard_us_region
+      URI.parse("https://#{SERVICE_NAME}-#{@region}.amazonaws.com")
+    end
+
+    # :nodoc:
+    private def standard_us_region
+      "us-east-1"
+    end
+
+    # :nodoc:
+    private def default_endpoint : URI
+      URI.parse("https://#{SERVICE_NAME}.amazonaws.com")
     end
 
     # :nodoc:

--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -4,13 +4,12 @@ require "uri"
 
 module Awscr::S3
   class Http
-    def initialize(@signer : Awscr::Signer::Signers::Interface,
-                   @region : String = standard_us_region,
-                   @custom_endpoint : String? = nil)
-      @endpoint = endpoint
+    def initialize(
+      @signer : Awscr::Signer::Signers::Interface,
+      @endpoint : URI
+    )
     end
 
-    @endpoint : URI
     @client : HTTP::Client?
 
     # Issue a DELETE request to the *path* with optional *headers*
@@ -116,23 +115,6 @@ module Awscr::S3
       else
         raise S3::Exception.new("server error: #{response.status_code}")
       end
-    end
-
-    # :nodoc:
-    private def endpoint : URI
-      return URI.parse(@custom_endpoint.to_s) if @custom_endpoint
-      return default_endpoint if @region == standard_us_region
-      URI.parse("https://#{SERVICE_NAME}-#{@region}.amazonaws.com")
-    end
-
-    # :nodoc:
-    private def standard_us_region
-      "us-east-1"
-    end
-
-    # :nodoc:
-    private def default_endpoint : URI
-      URI.parse("https://#{SERVICE_NAME}.amazonaws.com")
     end
 
     # :nodoc:

--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -6,7 +6,7 @@ module Awscr::S3
   class Http
     def initialize(
       @signer : Awscr::Signer::Signers::Interface,
-      @endpoint : URI
+      @endpoint : URI,
     )
     end
 


### PR DESCRIPTION
This PR moves region and endpoint resolution logic from `Awscr::S3::Http` into `Awscr::S3::Client`. The HTTP layer now receives a fully resolved URI from the client.

This makes it easier to:

- Access client.endpoint directly
- Wrap the client in higher-level tools
- Reuse the resolved endpoint and region for related functionality (e.g., generating presigned URLs)

The Http class is now purely transport-focused, with no knowledge of regions or endpoint logic.