### PR TITLE
Add configurable HTTP client factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Move endpoint to client and expose it. (#130, thanks @treagod)
+- Introduce a factory-based mechanism for `Awscr::S3::Http`, allowing for custom connection strategies (e.g. pooling). (#XXX, thanks @treagod)
 
 ### Chores
 
@@ -14,6 +15,11 @@
 ### Removed
 
 - The presigned old interfaces without aws_session_key argument. (#137, thanks @miry)
+
+### Breaking
+
+- `Awscr::S3::Http` no longer caches a single `HTTP::Client` for all requests. By default, each request now acquires a fresh client via the new factory. If you relied on persistent keep-alives or a single client across requests, consider implementing a custom factory to retain the old behavior.
+
 
 ## [0.9.0] - 2025-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Move endpoint to client and expose it. (#130, thanks @treagod)
-- Introduce a factory-based mechanism for `Awscr::S3::Http`, allowing for custom connection strategies (e.g. pooling). (#XXX, thanks @treagod)
+- Introduce a factory-based mechanism for `Awscr::S3::Http`, allowing for custom connection strategies (e.g. pooling). (#139, thanks @treagod)
 
 ### Chores
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ class PoolingHttpClientFactory < Awscr::S3::HttpClientFactory
     @pool = [] of HTTP::Client
   end
 
-  def acquire_raw_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
+  def acquire_raw_client(endpoint : URI) : HTTP::Client
     if @pool.size > 0
       @pool.pop.not_nil!
     elsif @created_count < @pool_size

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ class PoolingHttpClientFactory < Awscr::S3::HttpClientFactory
 
   def acquire_raw_client(endpoint : URI) : HTTP::Client
     if @pool.size > 0
-      @pool.pop.not_nil!
+      @pool.pop
     elsif @created_count < @pool_size
       @created_count += 1
       HTTP::Client.new(endpoint)

--- a/examples/custom_http_provider.cr
+++ b/examples/custom_http_provider.cr
@@ -1,0 +1,35 @@
+require "../src/awscr-s3"
+require "http"
+
+class PoolingHttpClientFactory < Awscr::S3::HttpClientFactory
+  getter pool : Array(HTTP::Client)
+  @created_count : Int32 = 0
+
+  def initialize(@pool_size : Int32 = 3)
+    @pool = [] of HTTP::Client
+  end
+
+  def acquire_raw_client(endpoint : URI) : HTTP::Client
+    if @pool.size > 0
+      @pool.pop.not_nil!
+    elsif @created_count < @pool_size
+      @created_count += 1
+      HTTP::Client.new(endpoint)
+    else
+      raise "No available clients in pool (limit of #{@pool_size} reached)"
+    end
+  end
+
+  def release(client : HTTP::Client?)
+    return unless client
+    @pool << client
+  end
+end
+
+client = Awscr::S3::Client.new(
+  "unused",
+  "key",
+  "secret",
+  endpoint: "http://127.0.0.1:9000",
+  client_factory: PoolingHttpClientFactory.new,
+)

--- a/examples/custom_http_provider.cr
+++ b/examples/custom_http_provider.cr
@@ -11,7 +11,7 @@ class PoolingHttpClientFactory < Awscr::S3::HttpClientFactory
 
   def acquire_raw_client(endpoint : URI) : HTTP::Client
     if @pool.size > 0
-      @pool.pop.not_nil!
+      @pool.pop
     elsif @created_count < @pool_size
       @created_count += 1
       HTTP::Client.new(endpoint)
@@ -26,7 +26,7 @@ class PoolingHttpClientFactory < Awscr::S3::HttpClientFactory
   end
 end
 
-client = Awscr::S3::Client.new(
+Awscr::S3::Client.new(
   "unused",
   "key",
   "secret",

--- a/spec/awscr-s3/http_client_factory/default_client_factory_spec.cr
+++ b/spec/awscr-s3/http_client_factory/default_client_factory_spec.cr
@@ -1,0 +1,37 @@
+require "./spec_helper"
+
+describe Awscr::S3::DefaultHttpClientFactory do
+  it "attaches a signer to the HTTP client" do
+    WebMock.stub(:get, "https://example.com/test").to_return(status: 200, body: "ok")
+
+    signer = Awscr::S3::DefaultHttpClientFactorySpec::SpySigner.new
+    factory = Awscr::S3::DefaultHttpClientFactory.new
+
+    client = factory.acquire_client(URI.parse("https://example.com"), signer)
+
+    response = client.get("/test")
+    response.body.should eq "ok"
+
+    signer.called.should be_true
+  end
+end
+
+module Awscr::S3::DefaultHttpClientFactorySpec
+  class SpySigner
+    include Awscr::Signer::Signers::Interface
+
+    getter called = false
+
+    def sign(request : HTTP::Request)
+      @called = true
+    end
+
+    def sign(string : String)
+      # unused in this test
+    end
+
+    def presign(request)
+      # unused in this test
+    end
+  end
+end

--- a/spec/awscr-s3/http_client_factory/default_client_factory_spec.cr
+++ b/spec/awscr-s3/http_client_factory/default_client_factory_spec.cr
@@ -12,7 +12,7 @@ describe Awscr::S3::DefaultHttpClientFactory do
     response = client.get("/test")
     response.body.should eq "ok"
 
-    signer.called.should be_true
+    signer.called?.should be_true
   end
 end
 
@@ -20,7 +20,7 @@ module Awscr::S3::DefaultHttpClientFactorySpec
   class SpySigner
     include Awscr::Signer::Signers::Interface
 
-    getter called = false
+    getter? called = false
 
     def sign(request : HTTP::Request)
       @called = true

--- a/spec/awscr-s3/http_client_factory/spec_helper.cr
+++ b/spec/awscr-s3/http_client_factory/spec_helper.cr
@@ -1,0 +1,1 @@
+require "../../spec_helper"

--- a/spec/awscr-s3/http_spec.cr
+++ b/spec/awscr-s3/http_spec.cr
@@ -76,7 +76,7 @@ module Awscr::S3
 
     describe "client_factory" do
       it "calls `#acquire_client` and `#release` for each request" do
-        factory = TestHttpClientFactory.new
+        factory = HttpClientFactoryMock.new
         http = Http.new(SIGNER, URI.parse("https://s3.amazonaws.com"), factory)
 
         WebMock.stub(:get, "https://s3.amazonaws.com/path").to_return(status: 200)

--- a/spec/awscr-s3/http_spec.cr
+++ b/spec/awscr-s3/http_spec.cr
@@ -74,6 +74,20 @@ module Awscr::S3
       end
     end
 
+    describe "client_factory" do
+      it "calls `#acquire_client` and `#release` for each request" do
+        factory = TestHttpClientFactory.new
+        http = Http.new(SIGNER, URI.parse("https://s3.amazonaws.com"), factory)
+
+        WebMock.stub(:get, "https://s3.amazonaws.com/path").to_return(status: 200)
+
+        http.get("/path")
+
+        factory.acquired_count.should eq(1)
+        factory.released_count.should eq(1)
+      end
+    end
+
     describe "get" do
       it "handles aws specific errors" do
         WebMock.stub(:get, "https://s3.amazonaws.com/sup?")

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -18,3 +18,4 @@ Spec.after_each do
 end
 
 require "../src/awscr-s3"
+require "./support/**"

--- a/spec/support/spec_helper.cr
+++ b/spec/support/spec_helper.cr
@@ -1,0 +1,1 @@
+require "../spec_helper"

--- a/spec/support/test_http_client_factory.cr
+++ b/spec/support/test_http_client_factory.cr
@@ -4,7 +4,7 @@ class TestHttpClientFactory < Awscr::S3::HttpClientFactory
   getter acquired_count = 0
   getter released_count = 0
 
-  def acquire_raw_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
+  def acquire_raw_client(endpoint : URI) : HTTP::Client
     @acquired_count += 1
     HTTP::Client.new(endpoint)
   end

--- a/spec/support/test_http_client_factory.cr
+++ b/spec/support/test_http_client_factory.cr
@@ -4,7 +4,7 @@ class TestHttpClientFactory < Awscr::S3::HttpClientFactory
   getter acquired_count = 0
   getter released_count = 0
 
-  def acquire_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
+  def acquire_raw_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
     @acquired_count += 1
     HTTP::Client.new(endpoint)
   end

--- a/spec/support/test_http_client_factory.cr
+++ b/spec/support/test_http_client_factory.cr
@@ -1,0 +1,15 @@
+require "./spec_helper"
+
+class TestHttpClientFactory < Awscr::S3::HttpClientFactory
+  getter acquired_count = 0
+  getter released_count = 0
+
+  def acquire_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
+    @acquired_count += 1
+    HTTP::Client.new(endpoint)
+  end
+
+  def release(client : HTTP::Client?)
+    @released_count += 1
+  end
+end

--- a/spec/support/test_http_client_factory.cr
+++ b/spec/support/test_http_client_factory.cr
@@ -1,6 +1,6 @@
 require "./spec_helper"
 
-class TestHttpClientFactory < Awscr::S3::HttpClientFactory
+class HttpClientFactoryMock < Awscr::S3::HttpClientFactory
   getter acquired_count = 0
   getter released_count = 0
 

--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -4,12 +4,12 @@ require "uri"
 
 module Awscr::S3
   class Http
-    @[Deprecated("Use `Http.new(signer, endpoint)` instead")]
+    @[Deprecated("Use `Http.new(signer, endpoint, factory)` instead")]
     def initialize(@signer : Awscr::Signer::Signers::Interface,
                    @region : String = standard_us_region,
-                   @custom_endpoint : String? = nil,
-                   @factory : HttpClientFactory = DefaultHttpClientFactory.new)
+                   @custom_endpoint : String? = nil,)
       @endpoint = endpoint
+      @factory = DefaultHttpClientFactory.new
     end
 
     def initialize(

--- a/src/awscr-s3/http_client_factory/default_client_factory.cr
+++ b/src/awscr-s3/http_client_factory/default_client_factory.cr
@@ -6,18 +6,8 @@ module Awscr::S3
   # for each request.
   class DefaultHttpClientFactory < HttpClientFactory
     # Acquires a new `HTTP::Client` instance configured for the given endpoint and signer.
-    def acquire_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
-      client = HTTP::Client.new(endpoint)
-      attach_signer(client, signer)
-      client
-    end
-
-    private def attach_signer(client, signer)
-      if signer.is_a?(Awscr::Signer::Signers::V4)
-        client.before_request { |req| signer.as(Awscr::Signer::Signers::V4).sign(req, encode_path: false) }
-      else
-        client.before_request { |req| signer.sign(req) }
-      end
+    def acquire_raw_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
+      HTTP::Client.new(endpoint)
     end
   end
 end

--- a/src/awscr-s3/http_client_factory/default_client_factory.cr
+++ b/src/awscr-s3/http_client_factory/default_client_factory.cr
@@ -1,0 +1,23 @@
+require "./http_client_factory"
+
+module Awscr::S3
+  # The default implementation of `HttpClientFactory` used to provide HTTP clients
+  # for communicating with S3. This factory creates a new `HTTP::Client` instance
+  # for each request.
+  class DefaultHttpClientFactory < HttpClientFactory
+    # Acquires a new `HTTP::Client` instance configured for the given endpoint and signer.
+    def acquire_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
+      client = HTTP::Client.new(endpoint)
+      attach_signer(client, signer)
+      client
+    end
+
+    private def attach_signer(client, signer)
+      if signer.is_a?(Awscr::Signer::Signers::V4)
+        client.before_request { |req| signer.as(Awscr::Signer::Signers::V4).sign(req, encode_path: false) }
+      else
+        client.before_request { |req| signer.sign(req) }
+      end
+    end
+  end
+end

--- a/src/awscr-s3/http_client_factory/default_client_factory.cr
+++ b/src/awscr-s3/http_client_factory/default_client_factory.cr
@@ -6,7 +6,7 @@ module Awscr::S3
   # for each request.
   class DefaultHttpClientFactory < HttpClientFactory
     # Acquires a new `HTTP::Client` instance configured for the given endpoint and signer.
-    def acquire_raw_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
+    def acquire_raw_client(endpoint : URI) : HTTP::Client
       HTTP::Client.new(endpoint)
     end
   end

--- a/src/awscr-s3/http_client_factory/http_client_factory.cr
+++ b/src/awscr-s3/http_client_factory/http_client_factory.cr
@@ -11,7 +11,7 @@ module Awscr::S3
     #
     # Override this method if you need custom logic beyond standard signing.
     def acquire_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
-      client = acquire_raw_client(endpoint, signer)
+      client = acquire_raw_client(endpoint)
       attach_signer(client, signer)
       client
     end
@@ -20,7 +20,7 @@ module Awscr::S3
     #
     # Subclasses must implement this method to construct or retrieve a client instance.
     # The returned client is not expected to have a signing hook attached yet.
-    abstract def acquire_raw_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
+    abstract def acquire_raw_client(endpoint : URI) : HTTP::Client
 
     # Releases the given HTTP client. This is called when the client is no longer needed.
     def release(client : HTTP::Client?)

--- a/src/awscr-s3/http_client_factory/http_client_factory.cr
+++ b/src/awscr-s3/http_client_factory/http_client_factory.cr
@@ -4,15 +4,35 @@ module Awscr::S3
   # client lifecycle — such as creating a new client per request, reusing a persistent
   # connection, or implementing client pooling.
   abstract class HttpClientFactory
-    # Acquires a configured `HTTP::Client` for the given endpoint and signer.
+    # Acquires a fully configured `HTTP::Client`, with the signer attached.
     #
-    # Implementations must return an `HTTP::Client` that is ready to be used
-    # for making signed HTTP requests to AWS services.
-    abstract def acquire_client(endpoint : URI, signer : Signers::Interface) : HTTP::Client
+    # Calls `acquire_raw_client` internally to retrieve a client and automatically
+    # attaches a signing hook using the provided `signer`.
+    #
+    # Override this method if you need custom logic beyond standard signing.
+    def acquire_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
+      client = acquire_raw_client(endpoint, signer)
+      attach_signer(client, signer)
+      client
+    end
+
+    # Acquires a raw `HTTP::Client` for the given `endpoint` and `signer`.
+    #
+    # Subclasses must implement this method to construct or retrieve a client instance.
+    # The returned client is not expected to have a signing hook attached yet.
+    abstract def acquire_raw_client(endpoint : URI, signer : Awscr::Signer::Signers::Interface) : HTTP::Client
 
     # Releases the given HTTP client. This is called when the client is no longer needed.
     def release(client : HTTP::Client?)
       # No-op
+    end
+
+    protected def attach_signer(client, signer)
+      if signer.is_a?(Awscr::Signer::Signers::V4)
+        client.before_request { |req| signer.as(Awscr::Signer::Signers::V4).sign(req, encode_path: false) }
+      else
+        client.before_request { |req| signer.sign(req) }
+      end
     end
   end
 end

--- a/src/awscr-s3/http_client_factory/http_client_factory.cr
+++ b/src/awscr-s3/http_client_factory/http_client_factory.cr
@@ -1,0 +1,18 @@
+module Awscr::S3
+  # Abstract factory for providing configured `HTTP::Client` instances used to
+  # communicate with AWS S3. This allows different implementations to manage
+  # client lifecycle — such as creating a new client per request, reusing a persistent
+  # connection, or implementing client pooling.
+  abstract class HttpClientFactory
+    # Acquires a configured `HTTP::Client` for the given endpoint and signer.
+    #
+    # Implementations must return an `HTTP::Client` that is ready to be used
+    # for making signed HTTP requests to AWS services.
+    abstract def acquire_client(endpoint : URI, signer : Signers::Interface) : HTTP::Client
+
+    # Releases the given HTTP client. This is called when the client is no longer needed.
+    def release(client : HTTP::Client?)
+      # No-op
+    end
+  end
+end


### PR DESCRIPTION

## Summary

This PR refactors the `Http` class to remove its persistent `HTTP::Client` usage and instead delegate the creation of HTTP clients to a new factory interface (`HttpClientFactory`). By doing so, each request can optionally acquire a client from a custom provide.

## What Changed

1. Removed the single `@client` field in `Http`:
  - Previously, `Http` stored one `HTTP::Client` instance and reused it for all requests.
  - Now, `Http` does not store any long-lived client. Instead, it calls a factory’s `#acquire_client` method on every request.
2. Introduced `HttpClientFactory` and `DefaultHttpClientFactory`:
  - `HttpClientFactory` is an abstract class with three key methods:
    - `#acquire_client(endpoint, signer)` – returns a fully configured `HTTP::Client`.
    - `#acquire_raw_client(endpoint, signer)` – returns a plain`HTTP::Client`, must be implemented by developer.
    - `#release(client)` – allows returning or cleaning up the client. (Default implementation is no-op.)
  - `DefaultHttpClientFactory` provides the current “create a new client each time” logic, so no immediate behavioral change occurs unless users swap in a different factory.
3.	New request lifecycle in Http:
  - Each HTTP request (e.g. delete, get, head, etc.) uses `acquire_client` to get a ready-to-use client.
  - After the request finishes (or fails), Http calls `release(client)` to allow the factory to clean up or recycle resources.

## How the New Mechanism Works

1.	Http obtains an HTTP::Client on demand:
  ```crystal
  client = @factory.acquire_client(@endpoint, @signer)
  ```
2.	Request Execution:
  - The `#exec` method sends the HTTP request using the acquired client.
  - Upon success or failure, we exit the loop and proceed to the ensure block.
3. Release:
  - `@factory.release(client)` is called, allowing the factory to decide whether to close, reuse, or discard the client.

Closes #77 
