### PR TITLE
Update release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
           body_path: tmp/release_changelog.md
           draft: true
           prerelease: false


### PR DESCRIPTION
The last release shaw, that the automation is not working.
The release is missing a name for the tag.
Make sure use the short name of the tag.