### PR TITLE
Update batch_delete to raise an error when no keys are provided

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         run: shards install
 
       - name: "[Test] Run specs"
+        # NOTICE: Set order 1 until fix the problem with https://github.com/crystal-lang/crystal/issues/9065
         run: crystal spec -v --error-trace --no-color --error-on-warnings --order 59005 --time
 
       - name: "[Test] Compile files with release flag"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - The deprecated HTTP initialization interface. (#144, thanks @miry)
 
+### Changed
+
+- The `bulk_delete` method now raises `ArgumentError` instead of `S3::Exception` when the number of keys is 0 or exceeds 1000. (#145, thanks @miry)
+
 ## [0.10.0] - 2025-04-21
 
 ### Changed

--- a/spec/awscr-s3/client_spec.cr
+++ b/spec/awscr-s3/client_spec.cr
@@ -96,12 +96,22 @@ module Awscr::S3
         result.deleted_objects.should eq([Response::BatchDeleteOutput::DeletedObject.new("testkey", "", "")])
       end
 
+      it "raises if zero keys" do
+        keys = [] of String
+
+        client = Client.new("us-east-1", "key", "secret")
+
+        expect_raises ArgumentError do
+          client.batch_delete("bucket", keys)
+        end
+      end
+
       it "raises if too many keys" do
         keys = ["test"] * 1001
 
         client = Client.new("us-east-1", "key", "secret")
 
-        expect_raises S3::Exception do
+        expect_raises ArgumentError do
           client.batch_delete("bucket", keys)
         end
       end


### PR DESCRIPTION
The S3 API returns a MalformedXML error if a delete request is sent with zero keys. This change adds an early check in the client to raise a more descriptive error before the request is made.