### PR TITLE
Enable running specs in batches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: "[Test] Run specs"
         # NOTICE: Set order 1 until fix the problem with https://github.com/crystal-lang/crystal/issues/9065
-        run: crystal spec -v --error-trace --no-color --error-on-warnings --order 59005 --time
+        run: scripts/run_batched_specs
         env:
           LOG_LEVEL: trace
           CRYSTAL_WORKERS: 1

--- a/scripts/run_batched_specs
+++ b/scripts/run_batched_specs
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+
+batch_number=10
+spec_files=$(find ./spec -name "*_spec.cr")
+num_files=$(echo "$spec_files" | wc -l)
+batch_size=$(( $num_files / $batch_number ))
+
+i=0
+while [ $i -lt $batch_number ]; do
+  batch_files=$(echo "$spec_files" | tail -n +$(( $batch_size * $i + 1 )) | head -$batch_size)
+
+  echo "Running batch $(($i + 1))..."
+  echo "$batch_files" | xargs crystal spec --no-color --error-on-warnings
+  i=$((i + 1))
+  echo ""
+done
+


### PR DESCRIPTION
Update the CI to run tests in batches, until the problem in Crystal with writing to STDOUT fixed.

> Unhandled exception: File not open for writing (IO::Error)