### PR TITLE
replace Util.encode with URI.encode_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - The `bulk_delete` method now raises `ArgumentError` instead of `S3::Exception` when the number of keys is 0 or exceeds 1000. (#145, thanks @miry)
+- Replace all usages of `Util.encode` with the standard library method `URI.encode_path`. (#153, thanks @treagod)
 
 ## [0.10.0] - 2025-04-21
 

--- a/scripts/run_batched_specs
+++ b/scripts/run_batched_specs
@@ -10,7 +10,7 @@ while [ $i -lt $batch_number ]; do
   batch_files=$(echo "$spec_files" | tail -n +$(( $batch_size * $i + 1 )) | head -$batch_size)
 
   echo "Running batch $(($i + 1))..."
-  echo "$batch_files" | xargs crystal spec --no-color --error-on-warnings
+  echo "$batch_files" | xargs crystal spec --no-color --error-on-warnings --exclude-warnings=spec/awscr-s3/util_spec.cr
   i=$((i + 1))
   echo ""
 done

--- a/src/awscr-s3/client.cr
+++ b/src/awscr-s3/client.cr
@@ -120,7 +120,7 @@ module Awscr::S3
     # ```
     def start_multipart_upload(bucket : String, object : String,
                                headers : Hash(String, String) = Hash(String, String).new)
-      resp = http.post("/#{bucket}/#{Util.encode(object)}?uploads", headers: headers)
+      resp = http.post("/#{bucket}/#{URI.encode_path(object)}?uploads", headers: headers)
 
       Response::StartMultipartUpload.from_response(resp)
     end
@@ -134,7 +134,7 @@ module Awscr::S3
     # ```
     def upload_part(bucket : String, object : String,
                     upload_id : String, part_number : Int32, part : IO | String)
-      resp = http.put("/#{bucket}/#{Util.encode(object)}?partNumber=#{part_number}&uploadId=#{upload_id}", part)
+      resp = http.put("/#{bucket}/#{URI.encode_path(object)}?partNumber=#{part_number}&uploadId=#{upload_id}", part)
 
       Response::UploadPartOutput.new(
         resp.headers["ETag"],
@@ -167,7 +167,7 @@ module Awscr::S3
         end
       end
 
-      resp = http.post("/#{bucket}/#{Util.encode(object)}?uploadId=#{upload_id}", body: body)
+      resp = http.post("/#{bucket}/#{URI.encode_path(object)}?uploadId=#{upload_id}", body: body)
       Response::CompleteMultipartUpload.from_response(resp)
     end
 
@@ -180,7 +180,7 @@ module Awscr::S3
     # p resp # => true
     # ```
     def abort_multipart_upload(bucket : String, object : String, upload_id : String)
-      resp = http.delete("/#{bucket}/#{Util.encode(object)}?uploadId=#{upload_id}")
+      resp = http.delete("/#{bucket}/#{URI.encode_path(object)}?uploadId=#{upload_id}")
 
       resp.status_code == 204
     end
@@ -208,7 +208,7 @@ module Awscr::S3
     # p resp # => true
     # ```
     def delete_object(bucket, object, headers : Hash(String, String) = Hash(String, String).new)
-      resp = http.delete("/#{bucket}/#{Util.encode(object)}", headers)
+      resp = http.delete("/#{bucket}/#{URI.encode_path(object)}", headers)
 
       resp.status_code == 204
     end
@@ -258,8 +258,8 @@ module Awscr::S3
     # ```
     def copy_object(bucket, source : String, destination : String,
                     headers : Hash(String, String) = {} of String => String)
-      headers["x-amz-copy-source"] = "/#{bucket}/#{Util.encode(source)}"
-      resp = http.put("/#{bucket}/#{Util.encode(destination)}", "", headers)
+      headers["x-amz-copy-source"] = "/#{bucket}/#{URI.encode_path(source)}"
+      resp = http.put("/#{bucket}/#{URI.encode_path(destination)}", "", headers)
       Response::CopyObjectOutput.from_response(resp)
     end
 
@@ -272,7 +272,7 @@ module Awscr::S3
     # ```
     def put_object(bucket, object : String, body : IO | String | Bytes,
                    headers : Hash(String, String) = Hash(String, String).new)
-      resp = http.put("/#{bucket}/#{Util.encode(object)}", body, headers)
+      resp = http.put("/#{bucket}/#{URI.encode_path(object)}", body, headers)
 
       Response::PutObjectOutput.from_response(resp)
     end
@@ -285,7 +285,7 @@ module Awscr::S3
     # p resp.body # => "MY DATA"
     # ```
     def get_object(bucket, object : String, headers : Hash(String, String) = Hash(String, String).new)
-      resp = http.get("/#{bucket}/#{Util.encode(object)}", headers: headers)
+      resp = http.get("/#{bucket}/#{URI.encode_path(object)}", headers: headers)
 
       Response::GetObjectOutput.from_response(resp)
     end
@@ -299,7 +299,7 @@ module Awscr::S3
     # end
     # ```
     def get_object(bucket, object : String, headers : Hash(String, String) = Hash(String, String).new, &)
-      http.get("/#{bucket}/#{Util.encode(object)}", headers: headers) do |resp|
+      http.get("/#{bucket}/#{URI.encode_path(object)}", headers: headers) do |resp|
         yield Response::GetObjectStream.from_response(resp)
       end
     end
@@ -316,7 +316,7 @@ module Awscr::S3
     # p resp.meta          # => {"my_tag" => "my_value"}
     # ```
     def head_object(bucket, object : String, headers : Hash(String, String) = Hash(String, String).new)
-      resp = http.head("/#{bucket}/#{Util.encode(object)}", headers: headers)
+      resp = http.head("/#{bucket}/#{URI.encode_path(object)}", headers: headers)
       Response::HeadObjectOutput.from_response(resp)
     end
 

--- a/src/awscr-s3/util.cr
+++ b/src/awscr-s3/util.cr
@@ -1,5 +1,6 @@
 module Awscr::S3
   module Util
+    # Remove --exclude-warnings=spec/awscr-s3/util_spec.cr from scripts/run_batched_specs on removal
     @[Deprecated("Use URI.encode_path instead")]
     def self.encode(object_id : String) : String
       String.build do |io|

--- a/src/awscr-s3/util.cr
+++ b/src/awscr-s3/util.cr
@@ -1,5 +1,6 @@
 module Awscr::S3
   module Util
+    @[Deprecated("Use URI.encode_path instead")]
     def self.encode(object_id : String) : String
       String.build do |io|
         URI.encode(object_id, io) { |byte| URI.unreserved?(byte) || byte.chr == '/' || byte.chr == '~' }


### PR DESCRIPTION
Use `URI.encode_path` from the standard library in favor of a custom solution.

[`Util.encode` was introduced 10.02.2021](https://github.com/taylorfinnell/awscr-s3/commit/f8492402d43dae4ea443d8c1d7afbdca051c6081) and [`URI.encode_path` 14.10.2021](https://crystal-lang.org/2021/10/14/1.2.0-released/) , just some months apart