### PR TITLE
Fixes #155: Add configurable multipart threshold/part size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add configurable multipart threshold/part size. (#155, thanks @dup2)
 - Introduced a `Presigner` class to simplify generating presigned URLs and forms. (#150, thanks @treagod)
 - Add `status`, `status_message` and `headers` attributes to all response objects. (#151, thanks @treagod)
 

--- a/src/awscr-s3/file_uploader.cr
+++ b/src/awscr-s3/file_uploader.cr
@@ -5,15 +5,17 @@ module Awscr::S3
   # If the file is greater than 5MB it is uploaded in parts.
   class FileUploader
     # :nodoc:
-    UPLOAD_THRESHOLD = 5_000_000 # 5mb
+    UPLOAD_THRESHOLD = (5 * 1024 * 1024).to_i64 # 5MB
 
     # Configurable options passed to a FileUploader instance
     struct Options
       # If true the uploader will automatically add a content type header
       getter with_content_types
       getter simultaneous_parts
+      getter minimum_part_size
+      getter multipart_threshold
 
-      def initialize(@with_content_types : Bool, @simultaneous_parts : Int32 = 5)
+      def initialize(@with_content_types : Bool, @simultaneous_parts : Int32 = 5, @minimum_part_size : Int64 = MultipartFileUploader::MIN_PART_SIZE, @multipart_threshold : Int64 = UPLOAD_THRESHOLD)
       end
     end
 
@@ -30,10 +32,10 @@ module Awscr::S3
     def upload(bucket : String, object : String, io : IO, headers : Hash(String, String) = Hash(String, String).new)
       headers = @options.with_content_types ? headers.merge(content_type_header(io)) : headers
 
-      if io.size < UPLOAD_THRESHOLD
+      if io.size < @options.multipart_threshold
         @client.put_object(bucket, object, io, headers)
       else
-        uploader = MultipartFileUploader.new(@client, @options.simultaneous_parts)
+        uploader = MultipartFileUploader.new(@client, @options.simultaneous_parts, @options.minimum_part_size)
         uploader.upload(bucket, object, io, headers)
       end
       true


### PR DESCRIPTION
Adds configurable values for 

* `multipart_threshold`: A Int64 to act as the threshold for when to switch to multipart uploads (defaults to 5MB)
* `multipart_part_size`: A Int64 to configure the minimum part size (defaults to 5MB)

These values should be used in accordance with the limits S3 defines, such as a max of 5GB for a single :put_object call.