### PR TITLE
fix: close HTTP connections in DefaultHttpClientFactory#release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - The deprecated HTTP initialization interface. (#144, thanks @miry)
 
+### Fixed
+
+- Close HTTP connections in `DefaultHttpClientFactory#release` to prevent CLOSE_WAIT socket leaks in long-running processes. (#160, thanks @usiegj00)
+
 ### Changed
 
 - The `bulk_delete` method now raises `ArgumentError` instead of `S3::Exception` when the number of keys is 0 or exceeds 1000. (#145, thanks @miry)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - The deprecated HTTP initialization interface. (#144, thanks @miry)
 
+### Fixed
+
+- Fix `SignatureDoesNotMatch` on paginated `ListObjectsV2` requests by using `URI.encode_www_form` for query string values to match V4 signer encoding. (#161, thanks @usiegj00)
+
 ### Changed
 
 - The `bulk_delete` method now raises `ArgumentError` instead of `S3::Exception` when the number of keys is 0 or exceeds 1000. (#145, thanks @miry)

--- a/spec/awscr-s3/client_spec.cr
+++ b/spec/awscr-s3/client_spec.cr
@@ -374,6 +374,64 @@ module Awscr::S3
         ])
       end
 
+      it "encodes continuation tokens containing slashes" do
+        resp = <<-RESP
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>bucket</Name>
+          <Prefix/>
+          <KeyCount>1</KeyCount>
+          <MaxKeys>1</MaxKeys>
+          <IsTruncated>true</IsTruncated>
+          <NextContinuationToken>metrics/2023_10/abc_bounces</NextContinuationToken>
+          <Contents>
+              <Key>my-image.jpg</Key>
+              <LastModified>2009-09-11T17:50:30.000Z</LastModified>
+              <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
+              <Size>434234</Size>
+              <StorageClass>STANDARD</StorageClass>
+          </Contents>
+        </ListBucketResult>
+        RESP
+
+        resp2 = <<-RESP
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>bucket</Name>
+          <Prefix/>
+          <KeyCount>1</KeyCount>
+          <MaxKeys>1</MaxKeys>
+          <IsTruncated>false</IsTruncated>
+          <Contents>
+              <Key>key2</Key>
+              <LastModified>2010-10-12T17:50:30.000Z</LastModified>
+              <ETag>"fba9dede5f27731c9771645a39863329"</ETag>
+              <Size>1337</Size>
+              <StorageClass>STANDARD</StorageClass>
+          </Contents>
+        </ListBucketResult>
+        RESP
+
+        # The continuation token must be percent-encoded in the URL:
+        # slashes must be %2F to match the V4 signer's canonical form
+        WebMock.stub(:get, "https://s3.amazonaws.com/bucket?list-type=2&max-keys=1&continuation-token=metrics%2F2023_10%2Fabc_bounces")
+          .to_return(body: resp2)
+
+        WebMock.stub(:get, "https://s3.amazonaws.com/bucket?list-type=2&max-keys=1")
+          .to_return(body: resp)
+
+        client = Client.new("us-east-1", "key", "secret")
+
+        objects = [] of Response::ListObjectsV2
+        client.list_objects("bucket", max_keys: 1).each do |output|
+          objects << output
+        end
+
+        objects.size.should eq(2)
+        objects.first.contents.first.key.should eq("my-image.jpg")
+        objects.last.contents.first.key.should eq("key2")
+      end
+
       it "supports basic case" do
         resp = <<-RESP
         <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/awscr-s3/http_client_factory/default_client_factory_close_spec.cr
+++ b/spec/awscr-s3/http_client_factory/default_client_factory_close_spec.cr
@@ -1,0 +1,45 @@
+require "./spec_helper"
+require "http/server"
+
+describe Awscr::S3::DefaultHttpClientFactory do
+  describe "#release" do
+    it "closes the HTTP client to prevent TCP connection leaks", tags: "integration" do
+      server = HTTP::Server.new do |context|
+        context.response.content_type = "text/plain"
+        context.response.print "ok"
+      end
+      address = server.bind_tcp("127.0.0.1", 0)
+      spawn { server.listen }
+
+      begin
+        factory = Awscr::S3::DefaultHttpClientFactory.new
+        endpoint = URI.parse("http://127.0.0.1:#{address.port}")
+        client = factory.acquire_raw_client(endpoint)
+
+        # Make a request to establish a TCP connection
+        response = client.get("/")
+        response.body.should eq "ok"
+
+        # Connection is open — @io holds the active socket
+        client.@io.should_not be_nil
+
+        # release() should close the connection
+        factory.release(client)
+
+        # After release, the connection should be closed.
+        # Without this fix, release() is a no-op and the TCP connection
+        # remains open. When the server eventually closes its end, the
+        # socket enters CLOSE_WAIT and stays there indefinitely — leaking
+        # one connection per S3 request in long-running processes.
+        client.@io.should be_nil
+      ensure
+        server.close
+      end
+    end
+
+    it "handles nil client gracefully" do
+      factory = Awscr::S3::DefaultHttpClientFactory.new
+      factory.release(nil)
+    end
+  end
+end

--- a/src/awscr-s3/http_client_factory/default_client_factory.cr
+++ b/src/awscr-s3/http_client_factory/default_client_factory.cr
@@ -3,11 +3,20 @@ require "./http_client_factory"
 module Awscr::S3
   # The default implementation of `HttpClientFactory` used to provide HTTP clients
   # for communicating with S3. This factory creates a new `HTTP::Client` instance
-  # for each request.
+  # for each request and closes it after use.
   class DefaultHttpClientFactory < HttpClientFactory
     # Acquires a new `HTTP::Client` instance configured for the given endpoint and signer.
     def acquire_raw_client(endpoint : URI) : HTTP::Client
       HTTP::Client.new(endpoint)
+    end
+
+    # Closes the HTTP client to release the underlying TCP connection.
+    #
+    # Without this, each S3 request leaks a keep-alive TCP connection.
+    # In long-running processes, these accumulate as CLOSE_WAIT sockets
+    # when the server closes its end, eventually exhausting memory.
+    def release(client : HTTP::Client?)
+      client.try &.close
     end
   end
 end

--- a/src/awscr-s3/paginators/list_object_v2.cr
+++ b/src/awscr-s3/paginators/list_object_v2.cr
@@ -30,7 +30,7 @@ module Awscr::S3::Paginator
 
     # :nodoc:
     private def query_string
-      @params.map { |k, v| "#{k}=#{URI.encode_path(v.to_s)}" }.join("&")
+      @params.map { |k, v| "#{k}=#{URI.encode_www_form(v.to_s, space_to_plus: false)}" }.join("&")
     end
   end
 end


### PR DESCRIPTION
## Problem

`DefaultHttpClientFactory` creates a new `HTTP::Client` for each S3 request via `acquire_raw_client`, but inherits the **no-op** `release()` from `HttpClientFactory`. The `HTTP::Client` holds a keep-alive TCP connection that is never closed.

`Http#exec` already calls `@factory.release(client)` in its `ensure` block — the cleanup infrastructure is in place — but the default factory doesn't actually do anything in `release`.

In long-running processes, each S3 operation leaks one TCP connection. When the S3 server eventually closes its end, the local socket enters `CLOSE_WAIT` and stays there indefinitely because `close()` is never called.

### Production impact

We run a long-lived Crystal server that uses awscr-s3 for S3-compatible object storage (DigitalOcean Spaces). After 15 days of uptime, one server had **22,697 leaked CLOSE_WAIT connections** consuming **6.1 of 6.2 GB RAM**, causing customer-facing `Net::ReadTimeout` errors.

## Fix

Override `release()` in `DefaultHttpClientFactory` to call `client.try &.close`, matching the acquire/release lifecycle that `Http#exec` already expects.

## Test

Added a spec that:
1. **Fails before the fix**: demonstrates the leak (`client.@io` remains non-nil after `release`)
2. **Passes after the fix**: verifies the connection is closed (`client.@io` is nil)

```
$ crystal spec spec/awscr-s3/http_client_factory/default_client_factory_close_spec.cr

# Before fix:
#   Expected: #<TCPSocket:fd 8> to be nil
#   1 failure

# After fix:
#   2 examples, 0 failures
```

All existing specs continue to pass.

## Note for custom HttpClientFactory users

This change only affects the default factory. Custom factory implementations that override `release()` are unaffected. If you rely on the current behavior of connections staying open after release (e.g., for connection pooling), your custom factory already overrides `release()` and won't be impacted.