### PR TITLE
fix: encode pagination query values with URI.encode_www_form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - The deprecated HTTP initialization interface. (#144, thanks @miry)
 
+### Fixed
+
+- Fix `SignatureDoesNotMatch` on paginated `ListObjectsV2` requests by using `URI.encode_www_form` for query string values to match V4 signer encoding. (#161, thanks @usiegj00)
+
 ### Changed
 
 - The `bulk_delete` method now raises `ArgumentError` instead of `S3::Exception` when the number of keys is 0 or exceeds 1000. (#145, thanks @miry)

--- a/spec/awscr-s3/client_spec.cr
+++ b/spec/awscr-s3/client_spec.cr
@@ -374,6 +374,64 @@ module Awscr::S3
         ])
       end
 
+      it "encodes continuation tokens containing slashes" do
+        resp = <<-RESP
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>bucket</Name>
+          <Prefix/>
+          <KeyCount>1</KeyCount>
+          <MaxKeys>1</MaxKeys>
+          <IsTruncated>true</IsTruncated>
+          <NextContinuationToken>metrics/2023_10/abc_bounces</NextContinuationToken>
+          <Contents>
+              <Key>my-image.jpg</Key>
+              <LastModified>2009-09-11T17:50:30.000Z</LastModified>
+              <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
+              <Size>434234</Size>
+              <StorageClass>STANDARD</StorageClass>
+          </Contents>
+        </ListBucketResult>
+        RESP
+
+        resp2 = <<-RESP
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>bucket</Name>
+          <Prefix/>
+          <KeyCount>1</KeyCount>
+          <MaxKeys>1</MaxKeys>
+          <IsTruncated>false</IsTruncated>
+          <Contents>
+              <Key>key2</Key>
+              <LastModified>2010-10-12T17:50:30.000Z</LastModified>
+              <ETag>"fba9dede5f27731c9771645a39863329"</ETag>
+              <Size>1337</Size>
+              <StorageClass>STANDARD</StorageClass>
+          </Contents>
+        </ListBucketResult>
+        RESP
+
+        # The continuation token must be percent-encoded in the URL:
+        # slashes must be %2F to match the V4 signer's canonical form
+        WebMock.stub(:get, "https://s3.amazonaws.com/bucket?list-type=2&max-keys=1&continuation-token=metrics%2F2023_10%2Fabc_bounces")
+          .to_return(body: resp2)
+
+        WebMock.stub(:get, "https://s3.amazonaws.com/bucket?list-type=2&max-keys=1")
+          .to_return(body: resp)
+
+        client = Client.new("us-east-1", "key", "secret")
+
+        objects = [] of Response::ListObjectsV2
+        client.list_objects("bucket", max_keys: 1).each do |output|
+          objects << output
+        end
+
+        objects.size.should eq(2)
+        objects.first.contents.first.key.should eq("my-image.jpg")
+        objects.last.contents.first.key.should eq("key2")
+      end
+
       it "supports basic case" do
         resp = <<-RESP
         <?xml version="1.0" encoding="UTF-8"?>

--- a/src/awscr-s3/paginators/list_object_v2.cr
+++ b/src/awscr-s3/paginators/list_object_v2.cr
@@ -30,7 +30,7 @@ module Awscr::S3::Paginator
 
     # :nodoc:
     private def query_string
-      @params.map { |k, v| "#{k}=#{URI.encode_path(v.to_s)}" }.join("&")
+      @params.map { |k, v| "#{k}=#{URI.encode_www_form(v.to_s, space_to_plus: false)}" }.join("&")
     end
   end
 end


### PR DESCRIPTION
## Summary

Fix `SignatureDoesNotMatch` errors on every paginated `ListObjectsV2` request when continuation tokens contain `/` characters (which they always do on DigitalOcean Spaces, where tokens are S3 key paths).

## Root Cause

The paginator encodes query string values with `URI.encode_path`, but the V4 signer re-encodes them with `URI.encode_www_form(space_to_plus: false)`. These functions disagree on which characters to percent-encode:

| Character | `URI.encode_path` (paginator) | `URI.encode_www_form` (signer) |
|-----------|------------------------------|-------------------------------|
| `/` | `/` (preserved) | `%2F` |
| `=` | `=` (preserved) | `%3D` |
| `+` | `+` (preserved) | `%2B` |
| `&` | `&` (preserved) | `%26` |

The wire URL uses the paginator's encoding, but the signature is computed from the signer's encoding. When the S3 server verifies the signature, it finds a mismatch.

**Example with a real DigitalOcean Spaces continuation token:**
```
Token: metrics/2023_10/abc_bounces

Wire URL:   continuation-token=metrics/2023_10/abc_bounces
Canonical:  continuation-token=metrics%2F2023_10%2Fabc_bounces
                                      ^^^         ^^^
                                   → SignatureDoesNotMatch
```

## The Fix

Change the paginator to use `URI.encode_www_form(v, space_to_plus: false)` — the same encoding the V4 signer uses. This ensures the wire URL and canonical signature always agree.

## History

- v0.8.3 used `URI.encode(string: v, space_to_plus: true)` — also wrong (preserves `/`)
- Current master uses `URI.encode_path(v)` — wrong (preserves `/`, `+`, `=`, `&`)
- This PR uses `URI.encode_www_form(v, space_to_plus: false)` — matches the signer

## Test

Added a test case with a continuation token containing slashes (`metrics/2023_10/abc_bounces`) that verifies the paginator correctly percent-encodes them as `%2F` in the request URL.
