### PR TITLE
Add If-None-Match support to put_object

### DIFF
--- a/spec/awscr-s3/client_spec.cr
+++ b/spec/awscr-s3/client_spec.cr
@@ -281,6 +281,36 @@ module Awscr::S3
         client = Client.new("us-east-1", "key", "secret")
         client.put_object("mybucket", "object.txt", io, {"x-amz-meta-name" => "object"})
       end
+
+      it "sends If-None-Match header when if_none_match is provided" do
+        WebMock.stub(:put, "https://s3.amazonaws.com/mybucket/object.txt")
+          .with(body: "Hello", headers: {"Content-Length" => "5", "If-None-Match" => "*"})
+          .to_return(body: "", headers: {"ETag" => "etag"})
+
+        client = Client.new("us-east-1", "key", "secret")
+        resp = client.put_object("mybucket", "object.txt", "Hello", if_none_match: "*")
+        resp.etag.should eq("etag")
+      end
+
+      it "raises PreconditionFailed when object already exists with if_none_match" do
+        error_body = <<-XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Error>
+            <Code>PreconditionFailed</Code>
+            <Message>At least one of the pre-conditions you specified did not hold</Message>
+          </Error>
+        XML
+
+        WebMock.stub(:put, "https://s3.amazonaws.com/mybucket/object.txt")
+          .with(body: "Hello", headers: {"Content-Length" => "5", "If-None-Match" => "*"})
+          .to_return(status: 412, body: error_body)
+
+        client = Client.new("us-east-1", "key", "secret")
+
+        expect_raises(PreconditionFailed) do
+          client.put_object("mybucket", "object.txt", "Hello", if_none_match: "*")
+        end
+      end
     end
 
     describe "copy_object" do

--- a/src/awscr-s3/client.cr
+++ b/src/awscr-s3/client.cr
@@ -270,8 +270,16 @@ module Awscr::S3
     # resp = client.put_object("bucket1", "obj", "MY DATA")
     # p resp.key # => "obj"
     # ```
+    #
+    # Conditional write (only if key does not exist):
+    #
+    # ```
+    # resp = client.put_object("bucket1", "obj", "MY DATA", if_none_match: "*")
+    # ```
     def put_object(bucket, object : String, body : IO | String | Bytes,
-                   headers : Hash(String, String) = Hash(String, String).new)
+                   headers : Hash(String, String) = Hash(String, String).new,
+                   if_none_match : String? = nil)
+      headers["If-None-Match"] = if_none_match if if_none_match
       resp = http.put("/#{bucket}/#{URI.encode_path(object)}", body, headers)
 
       Response::PutObjectOutput.from_response(resp)


### PR DESCRIPTION
Adds an optional `if_none_match` parameter to `put_object` for conditional writes. When provided, the `If-None-Match` header is sent with the PUT request. If the object already exists, S3 returns 412 and the existing `PreconditionFailed` exception is raised.

```crystal
client.put_object("bucket", "key", "body", if_none_match: "*")
```

## S3-compatible service support

| Provider | Supported | Reference |
|----------|-----------|-----------|
| Amazon S3 | Yes | [Conditional writes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html) |
| Google Cloud Storage | Yes | [Preconditions](https://cloud.google.com/storage/docs/request-preconditions#json-api) |
| DigitalOcean Spaces | Yes | [S3 compatibility](https://docs.digitalocean.com/products/spaces/reference/s3-compatibility/) |
| Backblaze B2 | Yes | [S3-compatible API](https://www.backblaze.com/docs/cloud-storage-s3-compatible-api) |
| MinIO | Yes | [S3 compatibility](https://min.io/docs/minio/linux/reference/s3-api-compatibility.html) |
| Cloudflare R2 | Yes | [S3 API compatibility](https://developers.cloudflare.com/r2/api/s3/api/) |