### PR TITLE
[Crystal 1.21.0 support] handle IO::EOFError when connections are closed

### DIFF
--- a/src/awscr-s3/http.cr
+++ b/src/awscr-s3/http.cr
@@ -84,6 +84,16 @@ module Awscr::S3
         client = @factory.acquire_client(@endpoint, @signer)
         resp = client.exec(method, path, headers, body)
         return handle_response!(resp)
+      rescue ex : IO::EOFError
+        # Since Crystal 1.21.0, the HTTP client raises IO::EOFError when the connection is closed
+        # (https://github.com/crystal-lang/crystal/pull/16981). Closing our client explicitly here,
+        # forces the connection pool to create a new one.
+        client.try &.close
+
+        Awscr::S3::Log.debug exception: ex, &.emit("Could not process a request (connection closed)",
+          retries: retries, method: method, path: path)
+        raise ex if retries > 2
+        retries += 1
       rescue ex : IO::Error
         Awscr::S3::Log.debug exception: ex, &.emit("Could not process a request", retries: retries, method: method, path: path)
         raise ex if retries > 2


### PR DESCRIPTION
Crystal 1.21.0 changed the error handling in the HTTP client (see https://github.com/crystal-lang/crystal/pull/16981).

We need to handle the IO::EOFError and force the client to be replaced. Otherwise, it leads to connection errors.

The change is backward compatible, because Crystal <1.21.0 does not throw this exception in this situation. So, it is not reached.

(Fixes https://github.com/philipp-classen/easy-awscr/issues/9 in easy-awscr.)