### PR TITLE
ci: bump ameba to latest (master) for Crystal 1.21 compatibility

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -19,7 +19,7 @@ jobs:
         run: shards install
 
       - name: "[Analysis] Run static analysis"
-        run: ./bin/ameba
+        run: crystal run lib/ameba/bin/ameba.cr
 
       - name: "[Analysis]  Check formatting"
         run: crystal tool format --check

--- a/shard.yml
+++ b/shard.yml
@@ -25,4 +25,4 @@ development_dependencies:
     branch: master
   ameba:
     github: crystal-ameba/ameba
-    version: 1.6.4
+    commit: f22db143abd884b4e08c2fcd91d99cf187fb56d1

--- a/spec/awscr-s3/bucket_spec.cr
+++ b/spec/awscr-s3/bucket_spec.cr
@@ -11,19 +11,19 @@ module Awscr::S3
     it "not equal to another bucket if name and creation time differ" do
       time = Time.local
       bucket = Bucket.new("test2", time)
-      (Bucket.new("test", Time.unix(Time.local.to_unix + 123)) == bucket).should eq(false)
+      (Bucket.new("test", Time.unix(Time.local.to_unix + 123)) == bucket).should be_false
     end
 
     it "has the same name as the string provided" do
       time = Time.local
       bucket = Bucket.new("test3", time)
-      (bucket == "test3").should eq(true)
+      (bucket == "test3").should be_true
     end
 
     it "has not the same name as the string provided" do
       time = Time.local
       bucket = Bucket.new("test4", time)
-      (bucket == "abcdef").should eq(false)
+      (bucket == "abcdef").should be_false
     end
 
     it "has a name" do

--- a/spec/awscr-s3/client_spec.cr
+++ b/spec/awscr-s3/client_spec.cr
@@ -58,7 +58,7 @@ module Awscr::S3
               <Message>Access Denied</Message>
             </Deleted>
           </DeleteResult>
-        XML
+          XML
 
         WebMock.stub(:post, "https://s3.amazonaws.com/bucket?delete")
           .with(body: "<?xml version=\"1.0\"?>\n<Delete><Object><Key>testkey</Key></Object></Delete>\n", headers: {"Content-MD5" => "Slga5acph5mH0Gagq5P2BQ==", "Content-Length" => "75"})
@@ -81,7 +81,7 @@ module Awscr::S3
               <Key>testkey</Key>
             </Deleted>
           </DeleteResult>
-        XML
+          XML
 
         WebMock.stub(:post, "https://s3.amazonaws.com/bucket?delete")
           .with(body: "<?xml version=\"1.0\"?>\n<Delete><Object><Key>testkey</Key></Object></Delete>\n", headers: {"Content-MD5" => "Slga5acph5mH0Gagq5P2BQ==", "Content-Length" => "75"})
@@ -286,12 +286,12 @@ module Awscr::S3
     describe "copy_object" do
       it "can copy an object from source to destination" do
         resp = <<-RESP
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CopyObjectResult>
-            <LastModified>2009-10-28T22:32:00</LastModified>
-            <ETag>&quot;etag&quot;</ETag>
-        <CopyObjectResult>
-        RESP
+          <?xml version="1.0" encoding="UTF-8"?>
+          <CopyObjectResult>
+              <LastModified>2009-10-28T22:32:00</LastModified>
+              <ETag>&quot;etag&quot;</ETag>
+          <CopyObjectResult>
+          RESP
 
         WebMock.stub(:put, "https://s3.amazonaws.com/mybucket/destination?")
           .with(body: "", headers: {"x-amz-copy-source" => "/mybucket/source"})
@@ -308,41 +308,41 @@ module Awscr::S3
     describe "list_objects" do
       it "handles pagination" do
         resp = <<-RESP
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
-          <Name>bucket</Name>
-          <Prefix/>
-          <KeyCount>1</KeyCount>
-          <MaxKeys>1</MaxKeys>
-          <IsTruncated>true</IsTruncated>
-          <NextContinuationToken>token</NextContinuationToken
-          <Contents>
-              <Key>my-image.jpg</Key>
-              <LastModified>2009-09-11T17:50:30.000Z</LastModified>
-              <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
-              <Size>434234</Size>
-              <StorageClass>STANDARD</StorageClass>
-          </Contents>
-        </ListBucketResult>
-        RESP
+          <?xml version="1.0" encoding="UTF-8"?>
+          <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix/>
+            <KeyCount>1</KeyCount>
+            <MaxKeys>1</MaxKeys>
+            <IsTruncated>true</IsTruncated>
+            <NextContinuationToken>token</NextContinuationToken
+            <Contents>
+                <Key>my-image.jpg</Key>
+                <LastModified>2009-09-11T17:50:30.000Z</LastModified>
+                <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
+                <Size>434234</Size>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>
+          </ListBucketResult>
+          RESP
 
         resp2 = <<-RESP
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
-          <Name>bucket</Name>
-          <Prefix/>
-          <KeyCount>1</KeyCount>
-          <MaxKeys>1</MaxKeys>
-          <IsTruncated>false</IsTruncated>
-          <Contents>
-              <Key>key2</Key>
-              <LastModified>2010-10-12T17:50:30.000Z</LastModified>
-              <ETag>"fba9dede5f27731c9771645a39863329"</ETag>
-              <Size>1337</Size>
-              <StorageClass>STANDARD</StorageClass>
-          </Contents>
-        </ListBucketResult>
-        RESP
+          <?xml version="1.0" encoding="UTF-8"?>
+          <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix/>
+            <KeyCount>1</KeyCount>
+            <MaxKeys>1</MaxKeys>
+            <IsTruncated>false</IsTruncated>
+            <Contents>
+                <Key>key2</Key>
+                <LastModified>2010-10-12T17:50:30.000Z</LastModified>
+                <ETag>"fba9dede5f27731c9771645a39863329"</ETag>
+                <Size>1337</Size>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>
+          </ListBucketResult>
+          RESP
 
         WebMock.stub(:get, "https://s3.amazonaws.com/bucket?list-type=2&max-keys=1&continuation-token=token")
           .to_return(body: resp2)
@@ -376,41 +376,41 @@ module Awscr::S3
 
       it "encodes continuation tokens containing slashes" do
         resp = <<-RESP
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
-          <Name>bucket</Name>
-          <Prefix/>
-          <KeyCount>1</KeyCount>
-          <MaxKeys>1</MaxKeys>
-          <IsTruncated>true</IsTruncated>
-          <NextContinuationToken>metrics/2023_10/abc_bounces</NextContinuationToken>
-          <Contents>
-              <Key>my-image.jpg</Key>
-              <LastModified>2009-09-11T17:50:30.000Z</LastModified>
-              <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
-              <Size>434234</Size>
-              <StorageClass>STANDARD</StorageClass>
-          </Contents>
-        </ListBucketResult>
-        RESP
+          <?xml version="1.0" encoding="UTF-8"?>
+          <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix/>
+            <KeyCount>1</KeyCount>
+            <MaxKeys>1</MaxKeys>
+            <IsTruncated>true</IsTruncated>
+            <NextContinuationToken>metrics/2023_10/abc_bounces</NextContinuationToken>
+            <Contents>
+                <Key>my-image.jpg</Key>
+                <LastModified>2009-09-11T17:50:30.000Z</LastModified>
+                <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
+                <Size>434234</Size>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>
+          </ListBucketResult>
+          RESP
 
         resp2 = <<-RESP
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
-          <Name>bucket</Name>
-          <Prefix/>
-          <KeyCount>1</KeyCount>
-          <MaxKeys>1</MaxKeys>
-          <IsTruncated>false</IsTruncated>
-          <Contents>
-              <Key>key2</Key>
-              <LastModified>2010-10-12T17:50:30.000Z</LastModified>
-              <ETag>"fba9dede5f27731c9771645a39863329"</ETag>
-              <Size>1337</Size>
-              <StorageClass>STANDARD</StorageClass>
-          </Contents>
-        </ListBucketResult>
-        RESP
+          <?xml version="1.0" encoding="UTF-8"?>
+          <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix/>
+            <KeyCount>1</KeyCount>
+            <MaxKeys>1</MaxKeys>
+            <IsTruncated>false</IsTruncated>
+            <Contents>
+                <Key>key2</Key>
+                <LastModified>2010-10-12T17:50:30.000Z</LastModified>
+                <ETag>"fba9dede5f27731c9771645a39863329"</ETag>
+                <Size>1337</Size>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>
+          </ListBucketResult>
+          RESP
 
         # The continuation token must be percent-encoded in the URL:
         # slashes must be %2F to match the V4 signer's canonical form
@@ -434,29 +434,29 @@ module Awscr::S3
 
       it "supports basic case" do
         resp = <<-RESP
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
-          <Name>blah</Name>
-          <Prefix/>
-          <KeyCount>205</KeyCount>
-          <MaxKeys>1000</MaxKeys>
-          <IsTruncated>false</IsTruncated>
-          <Contents>
-              <Key>my-image.jpg</Key>
-              <LastModified>2009-09-11T17:50:30.000Z</LastModified>
-              <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
-              <Size>434234</Size>
-              <StorageClass>STANDARD</StorageClass>
-          </Contents>
-          <Contents>
-              <Key>key2</Key>
-              <LastModified>2010-10-12T17:50:30.000Z</LastModified>
-              <ETag>&quot;fba9dede5f27731c9771645a39863329&quot;</ETag>
-              <Size>1337</Size>
-              <StorageClass>STANDARD</StorageClass>
-          </Contents>
-        </ListBucketResult>
-        RESP
+          <?xml version="1.0" encoding="UTF-8"?>
+          <ListBucketResult xmlns="https://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>blah</Name>
+            <Prefix/>
+            <KeyCount>205</KeyCount>
+            <MaxKeys>1000</MaxKeys>
+            <IsTruncated>false</IsTruncated>
+            <Contents>
+                <Key>my-image.jpg</Key>
+                <LastModified>2009-09-11T17:50:30.000Z</LastModified>
+                <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                <Size>434234</Size>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>
+            <Contents>
+                <Key>key2</Key>
+                <LastModified>2010-10-12T17:50:30.000Z</LastModified>
+                <ETag>&quot;fba9dede5f27731c9771645a39863329&quot;</ETag>
+                <Size>1337</Size>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>
+          </ListBucketResult>
+          RESP
 
         WebMock.stub(:get, "https://s3.amazonaws.com/blah?list-type=2")
           .to_return(body: resp)
@@ -480,20 +480,20 @@ module Awscr::S3
     describe "list_buckets" do
       it "returns buckets on success" do
         resp = <<-RESP
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ListAllMyBucketsResult xmlns="https://s3.amazonaws.com/doc/2006-03-01">
-          <Owner>
-            <ID>bcaf1ffd86f461ca5fb16fd081034f</ID>
-            <DisplayName>webfile</DisplayName>
-          </Owner>
-          <Buckets>
-            <Bucket>
-              <Name>quotes</Name>
-              <CreationDate>2006-02-03T16:45:09.000Z</CreationDate>
-            </Bucket>
-          </Buckets>
-        </ListAllMyBucketsResult>
-        RESP
+          <?xml version="1.0" encoding="UTF-8"?>
+          <ListAllMyBucketsResult xmlns="https://s3.amazonaws.com/doc/2006-03-01">
+            <Owner>
+              <ID>bcaf1ffd86f461ca5fb16fd081034f</ID>
+              <DisplayName>webfile</DisplayName>
+            </Owner>
+            <Buckets>
+              <Bucket>
+                <Name>quotes</Name>
+                <CreationDate>2006-02-03T16:45:09.000Z</CreationDate>
+              </Bucket>
+            </Buckets>
+          </ListAllMyBucketsResult>
+          RESP
 
         WebMock.stub(:get, "https://s3.amazonaws.com/?")
           .to_return(body: resp)

--- a/spec/awscr-s3/http_spec.cr
+++ b/spec/awscr-s3/http_spec.cr
@@ -11,7 +11,7 @@ module Awscr::S3
       <Resource>/mybucket/myfoto.jpg</Resource>
       <RequestId>4442587FB7D0A2F9</RequestId>
     </Error>
-  BODY
+    BODY
 
   describe Http do
     describe "initialize" do

--- a/spec/awscr-s3/object_spec.cr
+++ b/spec/awscr-s3/object_spec.cr
@@ -11,7 +11,7 @@ module Awscr::S3
 
     it "not equal to another object key size and etag" do
       object = Object.new("test2", 123, "etag", OBJECT_TEST_TIME)
-      (Object.new("test", 123, "asd", OBJECT_TEST_TIME) == object).should eq(false)
+      (Object.new("test", 123, "asd", OBJECT_TEST_TIME) == object).should be_false
     end
 
     it "has key" do

--- a/spec/awscr-s3/presigned/field_collection_spec.cr
+++ b/spec/awscr-s3/presigned/field_collection_spec.cr
@@ -58,7 +58,7 @@ module Awscr
         describe "[]" do
           it "returns nil if no key found" do
             fields = FieldCollection.new
-            fields["k"].should eq nil
+            fields["k"].should be_nil
           end
 
           it "can return a key value" do

--- a/spec/awscr-s3/presigned/form_spec.cr
+++ b/spec/awscr-s3/presigned/form_spec.cr
@@ -76,8 +76,8 @@ module Awscr
             end
 
             WebMock.stub(:post, "http://fake host/").to_return do |request|
-              request.headers.not_nil!["Content-Type"].nil?.should eq false
-              request.body.nil?.should eq false
+              request.headers.not_nil!["Content-Type"].nil?.should be_false
+              request.body.nil?.should be_false
 
               HTTP::Client::Response.new(200, body: "")
             end
@@ -107,8 +107,8 @@ module Awscr
             end
 
             WebMock.stub(:post, "http://fake host/").to_return do |request|
-              request.headers.not_nil!["Content-Type"].nil?.should eq false
-              request.body.nil?.should eq false
+              request.headers.not_nil!["Content-Type"].nil?.should be_false
+              request.body.nil?.should be_false
 
               HTTP::Client::Response.new(200, body: "")
             end

--- a/spec/awscr-s3/presigned/html_printer_spec.cr
+++ b/spec/awscr-s3/presigned/html_printer_spec.cr
@@ -45,18 +45,18 @@ module Awscr
           printer = HtmlPrinter.new(form)
 
           html = <<-HTML
-          <form action="http://test.s3.amazonaws.com" method="post" enctype="multipart/form-data">
-            <input type="hidden" name="bucket" value="test" /><br />
-            <input type="hidden" name="x-amz-credential" value="test/19700101/region/s3/aws4_request" /><br />
-            <input type="hidden" name="x-amz-algorithm" value="AWS4-HMAC-SHA256" /><br />
-            <input type="hidden" name="x-amz-date" value="19700101T000001Z" /><br />
-            <input type="hidden" name="policy" value="eyJleHBpcmF0aW9uIjoiMTk3MC0wMS0wMVQwMDowMDowMS4wMDBaIiwiY29uZGl0aW9ucyI6W3siYnVja2V0IjoidGVzdCJ9LHsieC1hbXotY3JlZGVudGlhbCI6InRlc3QvMTk3MDAxMDEvcmVnaW9uL3MzL2F3czRfcmVxdWVzdCJ9LHsieC1hbXotYWxnb3JpdGhtIjoiQVdTNC1ITUFDLVNIQTI1NiJ9LHsieC1hbXotZGF0ZSI6IjE5NzAwMTAxVDAwMDAwMVoifV19" /><br />
-            <input type="hidden" name="x-amz-signature" value="f509df9965f9cf92b77aabc6b81a6f2fd24f36d3a6daaf46e9704ef5c333ee88" />
+            <form action="http://test.s3.amazonaws.com" method="post" enctype="multipart/form-data">
+              <input type="hidden" name="bucket" value="test" /><br />
+              <input type="hidden" name="x-amz-credential" value="test/19700101/region/s3/aws4_request" /><br />
+              <input type="hidden" name="x-amz-algorithm" value="AWS4-HMAC-SHA256" /><br />
+              <input type="hidden" name="x-amz-date" value="19700101T000001Z" /><br />
+              <input type="hidden" name="policy" value="eyJleHBpcmF0aW9uIjoiMTk3MC0wMS0wMVQwMDowMDowMS4wMDBaIiwiY29uZGl0aW9ucyI6W3siYnVja2V0IjoidGVzdCJ9LHsieC1hbXotY3JlZGVudGlhbCI6InRlc3QvMTk3MDAxMDEvcmVnaW9uL3MzL2F3czRfcmVxdWVzdCJ9LHsieC1hbXotYWxnb3JpdGhtIjoiQVdTNC1ITUFDLVNIQTI1NiJ9LHsieC1hbXotZGF0ZSI6IjE5NzAwMTAxVDAwMDAwMVoifV19" /><br />
+              <input type="hidden" name="x-amz-signature" value="f509df9965f9cf92b77aabc6b81a6f2fd24f36d3a6daaf46e9704ef5c333ee88" />
 
-            <input type="file"   name="file" /> <br />
-            <input type="submit" name="submit" value="Upload" />
-          </form>
-          HTML
+              <input type="file"   name="file" /> <br />
+              <input type="submit" name="submit" value="Upload" />
+            </form>
+            HTML
 
           printer.print.gsub("\n", "").gsub(" ", "").should eq(html.gsub("\n", "").gsub(" ", ""))
         end

--- a/spec/awscr-s3/xml_spec.cr
+++ b/spec/awscr-s3/xml_spec.cr
@@ -26,7 +26,7 @@ module Awscr::S3
               <StorageClass>STANDARD</StorageClass>
           </Contents>
         </ListBucketResult>
-      RESP
+        RESP
 
       xml = XML.new(resp)
 
@@ -49,7 +49,7 @@ module Awscr::S3
             </Bucket>
           </Buckets>
         </ListAllMyBucketsResult>
-      RESP
+        RESP
 
       xml = XML.new(resp)
       xml.array("ListAllMyBucketsResult/Buckets/Bucket") do |node|
@@ -69,7 +69,7 @@ module Awscr::S3
             </Bucket>
           </Buckets>
         </ListAllMyBucketsResult>
-      RESP
+        RESP
 
       xml = XML.new(resp)
       xml.array("ListAllMyBucketsResult/Buckets/Bucket") do |node|

--- a/spec/fixtures.cr
+++ b/spec/fixtures.cr
@@ -7,7 +7,7 @@ module Fixtures
         <Key>#{key}</Key>
         <UploadId>#{upload_id}</UploadId>
       </InitiateMultipartUploadResult>
-    RESP
+      RESP
   end
 
   def self.complete_multipart_upload_response
@@ -19,6 +19,6 @@ module Fixtures
         <Key>test</Key>
         <ETag>"7611c6414e4b58f22ff9f59a2c1767b7-2"</ETag>
       </CompleteMultipartUploadResult>
-    RESP_BODY
+      RESP_BODY
   end
 end

--- a/spec/integration/minio_spec.cr
+++ b/spec/integration/minio_spec.cr
@@ -21,13 +21,13 @@ describe "minio flow", tags: "integration" do
 
   it "lists buckets" do
     actual = client.list_buckets
-    actual.should_not eq(nil)
+    actual.should_not be_nil
   end
 
   it "creates a bucket" do
     name = bucket_name + "createbucket"
     actual = client.put_bucket(name)
-    actual.should_not eq(nil)
+    actual.should_not be_nil
 
     list_buckets = client.list_buckets.buckets.map(&.name)
     list_buckets.should contain(name)
@@ -36,14 +36,14 @@ describe "minio flow", tags: "integration" do
   it "deletes a bucket" do
     client.put_bucket("awcr-s3-test-deletes-bucket")
     response = client.delete_bucket("awcr-s3-test-deletes-bucket")
-    response.should eq(true)
+    response.should be_true
   end
 
   it "creates an object and reads it" do
     key = "foo"
     body = "Content of the Key"
     actual = client.put_object(bucket_name, key, body)
-    actual.etag.should_not eq(nil)
+    actual.etag.should_not be_nil
 
     response = client.head_object(bucket_name, key)
     response.meta.should be_empty
@@ -64,7 +64,7 @@ describe "minio flow", tags: "integration" do
     actual.should contain("list_obj_b")
 
     response = client.batch_delete(bucket_name, ["list_obj_a", "list_obj_b"])
-    response.success?.should eq(true)
+    response.success?.should be_true
   end
 
   it "download object with presigned url" do
@@ -75,7 +75,7 @@ describe "minio flow", tags: "integration" do
     object = "/#{UUID.random}"
 
     response = client.put_object(bucket_name, object, "Howdy")
-    response.etag.should_not eq(nil)
+    response.etag.should_not be_nil
 
     options = Awscr::S3::Presigned::Url::Options.new(
       aws_access_key: ENV.fetch("S3_KEY", "admin"),

--- a/src/awscr-s3/exceptions.cr
+++ b/src/awscr-s3/exceptions.cr
@@ -1,5 +1,5 @@
 module Awscr::S3
-  private EXCEPTIONS = %w(
+  private EXCEPTIONS = %w[
     AccountProblem
     AllAccessDisabled
     AmbiguousGrantByEmailAddress
@@ -78,7 +78,7 @@ module Awscr::S3
     TooManyBuckets
     UnexpectedContent
     UnresolvableGrantByEmailAddress
-    UserKeyMustBeSpecified)
+    UserKeyMustBeSpecified]
 
   # Exception raised when S3 gives us a non 200 http status code. The error
   # will have a specific message from S3.
@@ -93,8 +93,8 @@ module Awscr::S3
 
         case code
           {% for error, i in EXCEPTIONS %}
-          when {{error}}
-            {{error.id}}.new(message)
+          when {{ error }}
+            {{ error.id }}.new(message)
           {% end %}
         else
           new("#{code}: #{message}")
@@ -105,7 +105,7 @@ module Awscr::S3
 
   {% for error in EXCEPTIONS %}
     # :nodoc:
-    class {{error.id}} < Exception
+    class {{ error.id }} < Exception
     end
   {% end %}
 end

--- a/src/awscr-s3/presigned/field_collection.cr
+++ b/src/awscr-s3/presigned/field_collection.cr
@@ -35,12 +35,12 @@ module Awscr
         # Access a key, by name, from the field collection. Returns the key if
         # found, otherwise returns nil.
         def [](key)
-          self.find { |field| clean_key(field.key) == clean_key(key) }.try(&.value)
+          find { |field| clean_key(field.key) == clean_key(key) }.try(&.value)
         end
 
         # Convert the collection to a hash in the form of key => value.
         def to_hash
-          self.reduce({} of String => String) do |hash, field|
+          reduce({} of String => String) do |hash, field|
             hash[field.key] = field.value
             hash
           end

--- a/src/awscr-s3/presigned/html_printer.cr
+++ b/src/awscr-s3/presigned/html_printer.cr
@@ -18,18 +18,18 @@ module Awscr
 
           inputs = @form.fields.map do |field|
             <<-INPUT
-            <input type="hidden" name="#{field.key}" value="#{field.value}" />
-            INPUT
+              <input type="hidden" name="#{field.key}" value="#{field.value}" />
+              INPUT
           end
 
           <<-HTML
-          <form action="#{@form.url}" method="post" enctype="multipart/form-data">
-            #{inputs.join(br)}
+            <form action="#{@form.url}" method="post" enctype="multipart/form-data">
+              #{inputs.join(br)}
 
-            <input type="file"   name="file" /> #{br}
-            <input type="submit" name="submit" value="Upload" />
-          </form>
-          HTML
+              <input type="file"   name="file" /> #{br}
+              <input type="submit" name="submit" value="Upload" />
+            </form>
+            HTML
         end
       end
     end

--- a/src/awscr-s3/presigned/post_policy.cr
+++ b/src/awscr-s3/presigned/post_policy.cr
@@ -18,7 +18,7 @@ module Awscr
         end
 
         # The expiration time of the `Policy`.
-        def expiration(time : Time | Nil)
+        def expiration(time : Time?)
           @expiration = time
         end
 


### PR DESCRIPTION
Ameba 1.6.4 fails to compile with Crystal 1.21: Crystal::Lexer no longer exposes `next_string_array_token` (src/ameba/tokenizer.cr), and the `preview_mt` flag is deprecated. Tracking the latest ameba (master / 1.7.0-dev) is required for the linter to build and run.