### PR TITLE
ci: replace bitnami minio

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     services:
       minio:
         # https://stackoverflow.com/questions/60849745/how-can-i-run-a-command-in-github-action-service-containers
-        image: public.ecr.aws/bitnami/minio:latest
+        image: quay.io/minio/minio
         env:
           MINIO_ROOT_USER: admin
           MINIO_ROOT_PASSWORD: password
@@ -34,6 +34,8 @@ jobs:
           --health-timeout=5s
           --health-retries=5
           --name minio-server
+          --entrypoint /usr/bin/minio
+        command: server /data
 
     name: Crystal ${{ matrix.crystal_version }}
     continue-on-error: ${{ matrix.experimental }}


### PR DESCRIPTION
Bitnami now hides all its images behind a license, so the Docker pull of
public.ecr.aws/bitnami/minio:latest fails with "repository not found"
and every CI run fails while starting the minio service container.

Switch the service image to the official quay.io/minio/minio and set the
explicit entrypoint plus `server /data` command, since the upstream image
does not start a server by default like the Bitnami one did.